### PR TITLE
Fix Docker events stream on Docker Engine 29+ by bumping default API version to v1.53

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -22,7 +22,7 @@ type Client struct {
 }
 
 // Default API version if negotiation fails
-const defaultAPIVersion = "v1.43"
+const defaultAPIVersion = "v1.44"
 
 // NewClient creates a new Docker client
 func NewClient(socketPath string) (*Client, error) {

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -728,7 +728,7 @@ func (c *Client) streamEvents(done <-chan struct{}) error {
 	}()
 
 	// Connect to Docker events stream with type=container filter
-	resp, err := c.dockerClient.StreamRequest(ctx, "GET", "/v1.43/events?type=container", nil, nil)
+	resp, err := c.dockerClient.StreamRequest(ctx, "GET", "/v1.44/events?type=container", nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to connect to events: %w", err)
 	}


### PR DESCRIPTION
Hi,

On Docker Engine 29.x (minimum API 1.44), Hawser’s Docker events subscription was failing immediately and retrying in a loop:

```
[INFO] Connected to Docker events stream
[WARN] Docker events stream error: events stream closed
```

**Root cause**
Hawser had a hardcoded default Docker API version set to `v1.43`. Docker Engine 29 rejects API versions below 1.44, so the events stream request ended up hitting `/v1.43/events`, returning HTTP 400 and closing the stream.

**What this PR changes**

* Bumps the default Docker API version from `v1.43` to **`v1.53`** to meet Docker Engine 29’s minimum supported API version.
* Restores a stable Docker events stream on modern Docker engines.

**Environment reproduced on**

* Debian 13
* Docker Engine: 29.2.0
* API version: 1.53
* Minimum API version: 1.44