### PR TITLE
Fix the event streaming on newer docker versions

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -174,7 +174,7 @@ func (c *Client) RequestRaw(ctx context.Context, method, path string, headers ma
 // StreamRequest makes a streaming request (for logs, exec, events)
 // Uses the pre-initialized streamClient which has no timeout and proper connection pooling
 func (c *Client) StreamRequest(ctx context.Context, method, path string, headers map[string]string, body io.Reader) (*http.Response, error) {
-	url := fmt.Sprintf("http://localhost%s", path)
+	url := fmt.Sprintf("http://localhost/%s%s", c.apiVersion, path)
 
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -319,11 +319,11 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			result.ExitCode = exitErr.ExitCode()
 		}
-		result.Error = stderr.String()
+		result.Error = strings.TrimSpace(stderr.String())
 		if result.Error == "" {
 			result.Error = err.Error()
 		}
-		log.Debugf("Compose failed: exit=%d error=%s", result.ExitCode, result.Error)
+		log.Errorf("Compose failed: exit=%d error=%s", result.ExitCode, result.Error)
 	} else {
 		log.Debugf("Compose completed: %s (project=%s)", op.Operation, op.ProjectName)
 	}

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -728,7 +728,7 @@ func (c *Client) streamEvents(done <-chan struct{}) error {
 	}()
 
 	// Connect to Docker events stream with type=container filter
-	resp, err := c.dockerClient.StreamRequest(ctx, "GET", "/v1.43/events?type=container", nil, nil)
+	resp, err := c.dockerClient.StreamRequest(ctx, "GET", "/events?type=container", nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to connect to events: %w", err)
 	}


### PR DESCRIPTION
Event streaming breaks on newer versions of docker. E.g. docker 29.1.5 has the API version `1.52 (minimum version 1.44)`. The hardcoded version 1.43 makes the API calls to docker fail with a 400.

```
Jan 28 22:28:56 hostname hawser[180794]: 2026/01/28 22:28:56 [DEBUG] Docker API (stream): GET /v1.43/events?type=container
Jan 28 22:28:56 hostname hawser[180794]: 2026/01/28 22:28:56 [DEBUG] Docker API stream started: GET /v1.43/events?type=container -> 400
Jan 28 22:28:56 hostname hawser[180794]: 2026/01/28 22:28:56 [INFO] Connected to Docker events stream
Jan 28 22:28:56 hostname hawser[180794]: 2026/01/28 22:28:56 [WARN] Docker events stream error: events stream closed
```

This change makes the streaming request use the negotiated docker API version instead of the hardcoded value.