### PR TITLE
feat: add healthcheck subcommand, drop wget from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --no-cache curl \
 
 # Generate apko.yaml for current target architecture only
 # We build single-arch to avoid multi-arch layer confusion in extraction
+# Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
 RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
     && printf '%s\n' \
     "contents:" \
@@ -44,7 +45,6 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - docker-cli" \
     "    - docker-compose=5.1.4-r0" \
     "    - docker-cli-buildx" \
-    "    - wget" \
     "entrypoint:" \
     "  command: /bin/sh -l" \
     "archs:" \
@@ -89,15 +89,14 @@ RUN mkdir -p /usr/libexec/docker/cli-plugins \
 VOLUME /data/stacks
 
 # Copy pre-built binary (provided by goreleaser)
-COPY hawser /usr/local/bin/hawser
-RUN chmod +x /usr/local/bin/hawser
+COPY --chmod=0755 hawser /usr/local/bin/hawser
 
 # Expose default port
 EXPOSE 2376
 
-# Health check - auto-detects TLS mode
+# Health check - uses the built-in subcommand (auto-detects TLS mode)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD if [ -n "$TLS_CERT" ]; then wget -q --spider --no-check-certificate https://localhost:${PORT}/_hawser/health; else wget -q --spider http://localhost:${PORT}/_hawser/health; fi || exit 1
+    CMD ["/usr/local/bin/hawser", "healthcheck"]
 
 # Run as root to access Docker socket (can be changed with --user flag)
 ENTRYPOINT ["/usr/local/bin/hawser"]

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -11,11 +11,11 @@ FROM alpine:3.21
 WORKDIR /app
 
 # Install required packages
+# Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
 RUN apk add --no-cache \
     ca-certificates \
     docker-cli \
     docker-cli-compose \
-    wget \
     && mkdir -p /data/stacks
 
 # Set up environment variables
@@ -33,15 +33,14 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
 VOLUME /data/stacks
 
 # Copy pre-built binary (provided by goreleaser)
-COPY hawser /usr/local/bin/hawser
-RUN chmod +x /usr/local/bin/hawser
+COPY --chmod=0755 hawser /usr/local/bin/hawser
 
 # Expose default port
 EXPOSE 2376
 
-# Health check - auto-detects TLS mode
+# Health check - uses the built-in subcommand (auto-detects TLS mode)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD if [ -n "$TLS_CERT" ]; then wget -q --spider --no-check-certificate https://localhost:${PORT}/_hawser/health; else wget -q --spider http://localhost:${PORT}/_hawser/health; fi || exit 1
+    CMD ["/usr/local/bin/hawser", "healthcheck"]
 
 # Run as root to access Docker socket (can be changed with --user flag)
 ENTRYPOINT ["/usr/local/bin/hawser"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -42,6 +42,7 @@ RUN apk add --no-cache curl \
     && chmod +x /usr/local/bin/apko
 
 # Generate apko.yaml for current target architecture only
+# Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
 RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
     && printf '%s\n' \
     "contents:" \
@@ -55,7 +56,6 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - busybox" \
     "    - docker-cli" \
     "    - docker-compose" \
-    "    - wget" \
     "entrypoint:" \
     "  command: /bin/sh -l" \
     "archs:" \
@@ -94,15 +94,14 @@ RUN mkdir -p /usr/libexec/docker/cli-plugins \
     && ln -s /usr/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 
 # Copy binary from builder
-COPY --from=builder /hawser /usr/local/bin/hawser
-RUN chmod +x /usr/local/bin/hawser
+COPY --from=builder --chmod=0755 /hawser /usr/local/bin/hawser
 
 # Expose default port
 EXPOSE 2376
 
-# Health check - auto-detects TLS mode
+# Health check - uses the built-in subcommand (auto-detects TLS mode)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD if [ -n "$TLS_CERT" ]; then wget -q --spider --no-check-certificate https://localhost:${PORT}/_hawser/health; else wget -q --spider http://localhost:${PORT}/_hawser/health; fi || exit 1
+    CMD ["/usr/local/bin/hawser", "healthcheck"]
 
 # Run as root to access Docker socket (can be changed with --user flag)
 ENTRYPOINT ["/usr/local/bin/hawser"]

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ The Hawser Docker image includes a built-in health check that verifies Docker co
 
 **How it works:**
 
-- The container runs `wget` against the `/_hawser/health` endpoint every 30 seconds
+- The container's `HEALTHCHECK` runs `hawser healthcheck`, which probes the `/_hawser/health` endpoint every 30 seconds (https with verification disabled when `TLS_CERT` is set). No `wget`/`curl` is shipped in the image.
 - Both modes expose a minimal HTTP server on the configured port (default: 2376) for health checks
 - The health check verifies that Hawser can communicate with the Docker daemon
 
@@ -424,7 +424,7 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -e DOCKHAND_SERVER_URL=wss://your-dockhand.example.com/api/hawser/connect \
   -e TOKEN=your-agent-token \
-  --health-cmd="wget -q --spider http://localhost:2376/_hawser/health || exit 1" \
+  --health-cmd="/usr/local/bin/hawser healthcheck" \
   --health-interval=30s \
   --health-timeout=5s \
   --health-retries=3 \

--- a/cmd/hawser/healthcheck.go
+++ b/cmd/hawser/healthcheck.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// runHealthcheck probes the local /_hawser/health endpoint and exits 0 on
+// success or 1 on failure. It is used as the container HEALTHCHECK command so
+// the image does not need to ship wget/curl. TLS mode is auto-detected: when
+// TLS_CERT is set, https is used with certificate verification disabled (the
+// listener cert is typically self-signed and only needs to prove it is up).
+func runHealthcheck() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "2376"
+	}
+
+	scheme := "http"
+	client := &http.Client{Timeout: 5 * time.Second}
+	if os.Getenv("TLS_CERT") != "" {
+		scheme = "https"
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // liveness probe only
+		}
+	}
+
+	resp, err := client.Get(fmt.Sprintf("%s://localhost:%s/_hawser/health", scheme, port))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		fmt.Fprintf(os.Stderr, "healthcheck: unexpected status %d\n", resp.StatusCode)
+		os.Exit(1)
+	}
+}

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -19,6 +19,13 @@ var (
 )
 
 func main() {
+	// "healthcheck" subcommand: used as the container HEALTHCHECK command so the
+	// image does not need wget/curl. Handled before flag parsing.
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		runHealthcheck()
+		return
+	}
+
 	// Define flags
 	showHelp := flag.Bool("help", false, "Show help message")
 	showVersion := flag.Bool("version", false, "Show version information")
@@ -107,6 +114,7 @@ func printHelp() {
 	fmt.Println("USAGE:")
 	fmt.Println("  hawser              Run in Edge mode (connects outbound to Dockhand)")
 	fmt.Println("  hawser standard     Run in Standard mode (HTTP server)")
+	fmt.Println("  hawser healthcheck  Probe the local /_hawser/health endpoint (exit 0/1)")
 	fmt.Println()
 	fmt.Println("OPTIONS:")
 	fmt.Println("  --help       Show this help message")


### PR DESCRIPTION
The container HEALTHCHECK previously shelled out to wget. Add a small "hawser healthcheck" subcommand that probes /_hawser/health (auto-detecting TLS via TLS_CERT, like the old shell command) and switch the HEALTHCHECK to use it. This removes the wget package from the image.

The /_hawser/health HTTP endpoint is unchanged.

Also use COPY --chmod instead of a separate RUN chmod for the binary.