### PR TITLE
feat: optional slim image variant without docker-buildx

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,12 +40,14 @@ archives:
       - scripts/hawser.service
 
 dockers:
+  # Full images (include the docker-buildx plugin)
   - image_templates:
       - "ghcr.io/finsys/hawser:{{ .Version }}-amd64"
       - "ghcr.io/finsys/hawser:latest-amd64"
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--build-arg=INCLUDE_BUILDX=true"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.source={{ .GitURL }}"
@@ -59,6 +61,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--build-arg=INCLUDE_BUILDX=true"
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.source={{ .GitURL }}"
@@ -66,6 +69,37 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
 
+  # Slim images (no docker-buildx plugin; ~65 MB smaller, deploy-only)
+  - image_templates:
+      - "ghcr.io/finsys/hawser:{{ .Version }}-slim-amd64"
+      - "ghcr.io/finsys/hawser:latest-slim-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=INCLUDE_BUILDX=false"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source={{ .GitURL }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    goarch: amd64
+    dockerfile: Dockerfile
+
+  - image_templates:
+      - "ghcr.io/finsys/hawser:{{ .Version }}-slim-arm64"
+      - "ghcr.io/finsys/hawser:latest-slim-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=INCLUDE_BUILDX=false"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source={{ .GitURL }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    goarch: arm64
+    dockerfile: Dockerfile
+
+  # ARMv7 (Alpine-based; Wolfi is 64-bit only and has no buildx here, so the
+  # same image backs both the regular and slim manifests)
   - image_templates:
       - "ghcr.io/finsys/hawser:{{ .Version }}-armv7"
       - "ghcr.io/finsys/hawser:latest-armv7"
@@ -81,6 +115,7 @@ dockers:
     dockerfile: Dockerfile.armv7
 
 docker_manifests:
+  # Full (default) tags
   - name_template: "ghcr.io/finsys/hawser:{{ .Version }}"
     image_templates:
       - "ghcr.io/finsys/hawser:{{ .Version }}-amd64"
@@ -91,6 +126,19 @@ docker_manifests:
     image_templates:
       - "ghcr.io/finsys/hawser:latest-amd64"
       - "ghcr.io/finsys/hawser:latest-arm64"
+      - "ghcr.io/finsys/hawser:latest-armv7"
+
+  # Slim tags (armv7 reuses the regular Alpine image)
+  - name_template: "ghcr.io/finsys/hawser:{{ .Version }}-slim"
+    image_templates:
+      - "ghcr.io/finsys/hawser:{{ .Version }}-slim-amd64"
+      - "ghcr.io/finsys/hawser:{{ .Version }}-slim-arm64"
+      - "ghcr.io/finsys/hawser:{{ .Version }}-armv7"
+
+  - name_template: "ghcr.io/finsys/hawser:latest-slim"
+    image_templates:
+      - "ghcr.io/finsys/hawser:latest-slim-amd64"
+      - "ghcr.io/finsys/hawser:latest-slim-arm64"
       - "ghcr.io/finsys/hawser:latest-armv7"
 
 checksum:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@
 # - Full transparency (no dependency on pre-built Chainguard images)
 # - Reproducible builds from open-source Wolfi packages
 # - Minimal attack surface with only required packages
+#
+# Build arg INCLUDE_BUILDX=false produces a slim image without the docker-buildx
+# plugin (~65 MB smaller). The slim image can deploy and manage compose stacks
+# but cannot build images on the host (e.g. "docker compose up --build").
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -16,6 +20,7 @@
 FROM alpine:3.21 AS os-builder
 
 ARG TARGETARCH
+ARG INCLUDE_BUILDX=true
 
 WORKDIR /work
 
@@ -31,6 +36,7 @@ RUN apk add --no-cache curl \
 # Generate apko.yaml for current target architecture only
 # We build single-arch to avoid multi-arch layer confusion in extraction
 # Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
+# The docker-cli-buildx package is only included when INCLUDE_BUILDX=true
 RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
     && printf '%s\n' \
     "contents:" \
@@ -44,12 +50,15 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - busybox" \
     "    - docker-cli" \
     "    - docker-compose=5.1.4-r0" \
-    "    - docker-cli-buildx" \
+    > apko.yaml \
+    && if [ "$INCLUDE_BUILDX" = "true" ]; then echo "    - docker-cli-buildx" >> apko.yaml; fi \
+    && printf '%s\n' \
     "entrypoint:" \
     "  command: /bin/sh -l" \
     "archs:" \
     "  - ${APKO_ARCH}" \
-    > apko.yaml
+    >> apko.yaml \
+    && cat apko.yaml
 
 # Build the OS tarball and extract rootfs
 # apko creates an OCI tarball - we need to extract the actual filesystem layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --no-cache curl \
 
 # Generate apko.yaml for current target architecture only
 # We build single-arch to avoid multi-arch layer confusion in extraction
+# Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
 RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
     && printf '%s\n' \
     "contents:" \
@@ -44,7 +45,6 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - docker-cli" \
     "    - docker-compose=5.1.4-r0" \
     "    - docker-cli-buildx" \
-    "    - wget" \
     "entrypoint:" \
     "  command: /bin/sh -l" \
     "archs:" \
@@ -89,15 +89,14 @@ RUN mkdir -p /usr/libexec/docker/cli-plugins \
 VOLUME /data/stacks
 
 # Copy pre-built binary (provided by goreleaser)
-COPY hawser /usr/local/bin/hawser
-RUN chmod +x /usr/local/bin/hawser
+COPY --chmod=0755 hawser /usr/local/bin/hawser
 
 # Expose default port
 EXPOSE 2376
 
-# Health check - auto-detects TLS mode
+# Health check - uses the built-in subcommand (auto-detects TLS mode)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD if [ -n "$TLS_CERT" ]; then wget -q --spider --no-check-certificate https://localhost:${PORT}/_hawser/health; else wget -q --spider http://localhost:${PORT}/_hawser/health; fi || exit 1
+    CMD ["/usr/local/bin/hawser", "healthcheck"]
 
 # Run as root to access Docker socket (can be changed with --user flag)
 ENTRYPOINT ["/usr/local/bin/hawser"]

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -11,11 +11,11 @@ FROM alpine:3.21
 WORKDIR /app
 
 # Install required packages
+# Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
 RUN apk add --no-cache \
     ca-certificates \
     docker-cli \
     docker-cli-compose \
-    wget \
     && mkdir -p /data/stacks
 
 # Set up environment variables
@@ -33,15 +33,14 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
 VOLUME /data/stacks
 
 # Copy pre-built binary (provided by goreleaser)
-COPY hawser /usr/local/bin/hawser
-RUN chmod +x /usr/local/bin/hawser
+COPY --chmod=0755 hawser /usr/local/bin/hawser
 
 # Expose default port
 EXPOSE 2376
 
-# Health check - auto-detects TLS mode
+# Health check - uses the built-in subcommand (auto-detects TLS mode)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD if [ -n "$TLS_CERT" ]; then wget -q --spider --no-check-certificate https://localhost:${PORT}/_hawser/health; else wget -q --spider http://localhost:${PORT}/_hawser/health; fi || exit 1
+    CMD ["/usr/local/bin/hawser", "healthcheck"]
 
 # Run as root to access Docker socket (can be changed with --user flag)
 ENTRYPOINT ["/usr/local/bin/hawser"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,10 @@
 # =============================================================================
 # Multi-stage Dockerfile for local development that builds Hawser from source
 # and uses Wolfi OS for a secure, vulnerability-free runtime.
+#
+# Build arg INCLUDE_BUILDX=false produces a slim image without the docker-buildx
+# plugin (~65 MB smaller). The slim image can deploy and manage compose stacks
+# but cannot build images on the host (e.g. "docker compose up --build").
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -30,6 +34,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o /hawser ./cm
 FROM alpine:3.21 AS os-builder
 
 ARG TARGETARCH
+ARG INCLUDE_BUILDX=true
 
 WORKDIR /work
 
@@ -43,6 +48,7 @@ RUN apk add --no-cache curl \
 
 # Generate apko.yaml for current target architecture only
 # Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
+# The docker-cli-buildx package is only included when INCLUDE_BUILDX=true
 RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
     && printf '%s\n' \
     "contents:" \
@@ -56,11 +62,15 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - busybox" \
     "    - docker-cli" \
     "    - docker-compose" \
+    > apko.yaml \
+    && if [ "$INCLUDE_BUILDX" = "true" ]; then echo "    - docker-cli-buildx" >> apko.yaml; fi \
+    && printf '%s\n' \
     "entrypoint:" \
     "  command: /bin/sh -l" \
     "archs:" \
     "  - ${APKO_ARCH}" \
-    > apko.yaml
+    >> apko.yaml \
+    && cat apko.yaml
 
 # Build the OS tarball and extract rootfs
 RUN apko build apko.yaml hawser-base:latest output.tar \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -42,6 +42,7 @@ RUN apk add --no-cache curl \
     && chmod +x /usr/local/bin/apko
 
 # Generate apko.yaml for current target architecture only
+# Note: no wget/curl - the HEALTHCHECK uses the built-in "hawser healthcheck"
 RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
     && printf '%s\n' \
     "contents:" \
@@ -55,7 +56,6 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - busybox" \
     "    - docker-cli" \
     "    - docker-compose" \
-    "    - wget" \
     "entrypoint:" \
     "  command: /bin/sh -l" \
     "archs:" \
@@ -94,15 +94,14 @@ RUN mkdir -p /usr/libexec/docker/cli-plugins \
     && ln -s /usr/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 
 # Copy binary from builder
-COPY --from=builder /hawser /usr/local/bin/hawser
-RUN chmod +x /usr/local/bin/hawser
+COPY --from=builder --chmod=0755 /hawser /usr/local/bin/hawser
 
 # Expose default port
 EXPOSE 2376
 
-# Health check - auto-detects TLS mode
+# Health check - uses the built-in subcommand (auto-detects TLS mode)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD if [ -n "$TLS_CERT" ]; then wget -q --spider --no-check-certificate https://localhost:${PORT}/_hawser/health; else wget -q --spider http://localhost:${PORT}/_hawser/health; fi || exit 1
+    CMD ["/usr/local/bin/hawser", "healthcheck"]
 
 # Run as root to access Docker socket (can be changed with --user flag)
 ENTRYPOINT ["/usr/local/bin/hawser"]

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ The Hawser Docker image includes a built-in health check that verifies Docker co
 
 **How it works:**
 
-- The container runs `wget` against the `/_hawser/health` endpoint every 30 seconds
+- The container's `HEALTHCHECK` runs `hawser healthcheck`, which probes the `/_hawser/health` endpoint every 30 seconds (https with verification disabled when `TLS_CERT` is set). No `wget`/`curl` is shipped in the image.
 - Both modes expose a minimal HTTP server on the configured port (default: 2376) for health checks
 - The health check verifies that Hawser can communicate with the Docker daemon
 
@@ -424,7 +424,7 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -e DOCKHAND_SERVER_URL=wss://your-dockhand.example.com/api/hawser/connect \
   -e TOKEN=your-agent-token \
-  --health-cmd="wget -q --spider http://localhost:2376/_hawser/health || exit 1" \
+  --health-cmd="/usr/local/bin/hawser healthcheck" \
   --health-interval=30s \
   --health-timeout=5s \
   --health-retries=3 \

--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ sudo journalctl -u hawser -f
 
 ### Docker
 
+> **Image variants:** `ghcr.io/finsys/hawser:latest` is the full image and bundles the `docker-buildx`
+> plugin, so stacks can build images on the host (`docker compose up --build`).
+> `ghcr.io/finsys/hawser:latest-slim` drops the buildx plugin (~65 MB smaller) — use it when the agent
+> only deploys pre-built images. Deploying from an image works on both; building from source does not work
+> on the slim image. Both are multi-arch (armv7 is shared between the two tags).
+
 > **Important:** If your compose stacks use relative file bind mounts (e.g., `./config.conf:/app/config.conf`),
 > you **must** use a host path bind mount for `STACKS_DIR` — not a named volume. The path inside the container
 > must match the host path, because Docker daemon resolves bind mount sources on the host filesystem.
@@ -364,7 +370,7 @@ docker run -d \
   hawser:local
 ```
 
-**Note**: The default `Dockerfile` is used by GoReleaser for release builds and expects a pre-built binary. Use `Dockerfile.dev` for building from source.
+**Note**: The default `Dockerfile` is used by GoReleaser for release builds and expects a pre-built binary. Use `Dockerfile.dev` for building from source. Both accept `--build-arg INCLUDE_BUILDX=false` to produce the slim (no buildx plugin) variant.
 
 ### Multi-architecture builds
 
@@ -514,6 +520,9 @@ Hawser includes Docker Compose support for stack operations:
 - `pull` - Pull images
 - `ps` - List services
 - `logs` - View logs
+
+> Building images on the host (`docker compose up --build`) requires the `docker-buildx` plugin, which
+> is present in the full image only — not in the `-slim` image.
 
 ### Host Metrics
 

--- a/cmd/hawser/healthcheck.go
+++ b/cmd/hawser/healthcheck.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// runHealthcheck probes the local /_hawser/health endpoint and exits 0 on
+// success or 1 on failure. It is used as the container HEALTHCHECK command so
+// the image does not need to ship wget/curl. TLS mode is auto-detected: when
+// TLS_CERT is set, https is used with certificate verification disabled (the
+// listener cert is typically self-signed and only needs to prove it is up).
+func runHealthcheck() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "2376"
+	}
+
+	scheme := "http"
+	client := &http.Client{Timeout: 5 * time.Second}
+	if os.Getenv("TLS_CERT") != "" {
+		scheme = "https"
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // liveness probe only
+		}
+	}
+
+	resp, err := client.Get(fmt.Sprintf("%s://localhost:%s/_hawser/health", scheme, port))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "healthcheck: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		fmt.Fprintf(os.Stderr, "healthcheck: unexpected status %d\n", resp.StatusCode)
+		os.Exit(1)
+	}
+}

--- a/cmd/hawser/main.go
+++ b/cmd/hawser/main.go
@@ -19,6 +19,13 @@ var (
 )
 
 func main() {
+	// "healthcheck" subcommand: used as the container HEALTHCHECK command so the
+	// image does not need wget/curl. Handled before flag parsing.
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		runHealthcheck()
+		return
+	}
+
 	// Define flags
 	showHelp := flag.Bool("help", false, "Show help message")
 	showVersion := flag.Bool("version", false, "Show version information")
@@ -107,6 +114,7 @@ func printHelp() {
 	fmt.Println("USAGE:")
 	fmt.Println("  hawser              Run in Edge mode (connects outbound to Dockhand)")
 	fmt.Println("  hawser standard     Run in Standard mode (HTTP server)")
+	fmt.Println("  hawser healthcheck  Probe the local /_hawser/health endpoint (exit 0/1)")
 	fmt.Println()
 	fmt.Println("OPTIONS:")
 	fmt.Println("  --help       Show this help message")


### PR DESCRIPTION
> **Stacked on PR #69**

## What & why

The image is ~165 MB, of which the three Docker CLIs are the bulk:
`docker-cli` (~40 MB) + `docker-compose` (~29 MB) + `docker-cli-buildx` (~65 MB).
`buildx` is only needed when a stack actually builds an image on the host
(`docker compose up --build` / `--no-cache`). Plenty of agents only ever deploy
pre-built images and never need it.

This PR makes the buildx plugin optional via a build arg, so a much smaller
"slim" image can be published alongside the full one.

## Changes

- `Dockerfile` / `Dockerfile.dev`: add `ARG INCLUDE_BUILDX=true`; the
  `docker-cli-buildx` package is only added to the apko package list when
  `INCLUDE_BUILDX=true`.
- `.goreleaser.yml`: also build & publish `ghcr.io/finsys/hawser:<version>-slim`
  and `:latest-slim` manifests (`amd64` + `arm64` built with
  `--build-arg INCLUDE_BUILDX=false`). `armv7` is Alpine-based and never carried
  the buildx plugin, so the existing `armv7` image is reused in the slim manifest.
- `Dockerfile.dev` now installs the buildx plugin by default too, matching the
  release `Dockerfile` (it was previously missing it).
- `README.md`: short note on the two variants.

## Image sizes (local build, arm64)

| Image | Size |
|---|---|
| full (`INCLUDE_BUILDX=true`, default) | ~164 MB |
| slim (`INCLUDE_BUILDX=false`) | ~96 MB |

## Behaviour trade-off

The slim image can deploy, pull, and manage compose stacks (`up`, `down`,
`pull`, `ps`, `logs`, `restart`, `stop`, `start`), and all Docker-API proxy
features work normally. It **cannot build images on the host** — i.e. a stack
that has `build:` directives (or the Dockhand "Build images" / "No build cache"
options) will fail on the slim image. Use the full `:latest` image on hosts that
build stacks from source; use `:latest-slim` on hosts that only run pre-built
registry images. Default tags (`:latest`, `:<version>`) are unchanged.

## Testing

- `docker build` (full) → buildx present, healthcheck reports `healthy`.
- `docker build --build-arg INCLUDE_BUILDX=false` → `docker buildx` absent,
  `docker`/`docker compose` work, image ~96 MB.
- Same checks against `Dockerfile.dev` (both variants).
- Built for `linux/amd64`, pushed to a private registry, and run against a live
  Dockhand instance in both Edge and Standard modes — agent connects, metrics
  flow, and all non-build compose operations behave identically to the current
  image.

## Notes for reviewers

- This is intentionally conservative: no changes to the default image contents,
  no new runtime deps, the slim variant is purely additive (extra tags).
- If you'd rather the slim agent return a clearer "buildx not available" error to
  Dockhand when a build is requested (instead of surfacing compose's own
  message), happy to add that — let me know.