### PR TITLE
feat: add custom auth header support in edge mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ Hawser is configured via environment variables:
 |----------|-------------|---------|
 | `DOCKHAND_SERVER_URL` | WebSocket URL for Edge mode | - |
 | `TOKEN` | Authentication token | - |
+| `CUSTOM_AUTH_HEADER` | Name for custom auth header (e.g., `Authorization`, `X-Authentik-Token`) | - |
+| `CUSTOM_AUTH_TOKEN`  | Value for custom auth header (e.g., `Basic <token>`, `Bearer <token>`) | - |
 | `CA_CERT` | Path to CA certificate for Edge mode (self-signed Dockhand) | - |
 | `TLS_SKIP_VERIFY` | Skip TLS verification for Edge mode (insecure) | `false` |
 | `PORT` | HTTP server port (Standard mode) | `2376` |
@@ -562,6 +564,11 @@ When disabled, disk metrics will show as 0 in Dockhand (displayed as "N/A").
 ### Docker API Version Compatibility
 
 Hawser automatically negotiates the Docker API version with the daemon. When running Docker Compose operations, Hawser sets the `DOCKER_API_VERSION` environment variable to match the daemon's reported API version. This ensures compatibility when the Docker CLI version differs from the daemon version - for example, when using an older Docker CLI with a newer Docker daemon that requires a higher minimum API version.
+
+### Custom Auth Header (Edge Mode)
+
+If your Dockhand server is protected by an external authentication layer (like Traefik with ForwardAuth, Authentik, or Cloudflare Access), the Hawser agent needs to pass a custom header to authenticate and establish the WebSocket connection.
+You can use `CUSTOM_AUTH_HEADER` and `CUSTOM_AUTH_TOKEN` to inject this header into the connection request.
 
 ## API Endpoints
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	CACert            string // Optional CA certificate path (for self-signed Dockhand)
 	TLSSkipVerify     bool   // Skip TLS verification (insecure, for testing)
 
+    // Custom Proxy Authentication
+    CustomAuthHeader string // Header name, e.g., "Authorization" or "X-Authentik-Token"
+    CustomAuthToken  string // Header value, e.g., "Bearer <token>"
+	
 	// Standard Mode (passive HTTP server)
 	Port        int    // Default: 2376
 	BindAddress string // Default: 0.0.0.0 (all interfaces)
@@ -57,6 +61,10 @@ func Load() (*Config, error) {
 		Token:             os.Getenv("TOKEN"),
 		CACert:            os.Getenv("CA_CERT"),
 		TLSSkipVerify:     getEnvBool("TLS_SKIP_VERIFY", false),
+
+        // Custom Proxy Authentication
+        CustomAuthHeader: os.Getenv("CUSTOM_AUTH_HEADER"),
+        CustomAuthToken:  os.Getenv("CUSTOM_AUTH_TOKEN"),
 
 		// Standard mode
 		Port:        getEnvInt("PORT", 2376),

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -199,7 +199,15 @@ func (c *Client) connect() error {
 		dialer.TLSClientConfig = tlsConfig
 	}
 
-	conn, _, err := dialer.Dial(c.cfg.DockhandServerURL, nil)
+    var headers http.Header = nil
+
+    if c.cfg.CustomAuthHeader != "" && c.cfg.CustomAuthToken != "" {
+        headers = make(http.Header)
+        headers.Add(c.cfg.CustomAuthHeader, c.cfg.CustomAuthToken)
+        log.Infof("Using custom authentication header: %s", c.cfg.CustomAuthHeader)
+    }
+
+	conn, _, err := dialer.Dial(c.cfg.DockhandServerURL, headers)
 	if err != nil {
 		return fmt.Errorf("WebSocket dial failed: %w", err)
 	}


### PR DESCRIPTION
## Summary 

Adds custom authentication header support for Edge Mode to allow connections through external authentication proxies (like Traefik with ForwardAuth, Authentik, or Cloudflare Access).

Previously, the Hawser agent could not pass extra HTTP headers when establishing the WebSocket connection to the Dockhand server. If the server was protected by an authentication layer, the connection was rejected and failed with:
`WebSocket dial failed: websocket: bad handshake`

## Changes

- `internal/config/config.go` : Added CUSTOM_AUTH_HEADER and CUSTOM_AUTH_TOKEN environment variables to the configuration.
- `internal/edge/client.go` : Updated the WebSocket dialer to check for the custom auth variables and inject them into the HTTP request headers during the handshake. Added `[INFO] Using custom authentication header: ...` logging.
- `README.md`: Added documentation and usage examples for the new environment variables.

## Usage
docker-compose.yml:
```
environment:
  - CUSTOM_AUTH_HEADER=Authorization
  - CUSTOM_AUTH_TOKEN=Basic <your-token>
```
docker run:
`-e CUSTOM_AUTH_HEADER=Authorization -e CUSTOM_AUTH_TOKEN="Bearer <token>"`

Where the token is used to authenticate the Hawser agent against the external authentication layer in front of the Dockhand server.