### PR TITLE
fix: share an explicit DOCKER_CONFIG between docker login and compose so private pulls work under ProtectHome

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -133,8 +133,29 @@ type ComposeResult struct {
 	SkippedFiles []SkippedFile `json:"skippedFiles,omitempty"`
 }
 
-// loginToRegistries logs into all provided registries before compose operations
-func (c *ComposeClient) loginToRegistries(ctx context.Context, registries []RegistryCredentials) {
+// dockerEnv builds a minimal, clean environment for invoking the docker CLI,
+// so host vars (DOCKER_CONTEXT, DOCKER_TLS_VERIFY, ...) can't redirect docker.
+// dockerConfigDir, when set, is where credentials are read from / written to.
+func (c *ComposeClient) dockerEnv(dockerConfigDir string) []string {
+	env := []string{fmt.Sprintf("DOCKER_HOST=unix://%s", c.dockerSocket)}
+	if dockerConfigDir != "" {
+		env = append(env, "DOCKER_CONFIG="+dockerConfigDir)
+	}
+	for _, key := range []string{"PATH", "HOME", "USER"} {
+		if val, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+val)
+		}
+	}
+	if c.apiVersion != "" {
+		env = append(env, "DOCKER_API_VERSION="+c.apiVersion)
+	}
+	return env
+}
+
+// loginToRegistries runs `docker login` for each registry before a compose
+// up/pull. dockerConfigDir is the writable Docker config the credentials are
+// stored in; it must match the one passed to the compose command (see Execute).
+func (c *ComposeClient) loginToRegistries(ctx context.Context, registries []RegistryCredentials, dockerConfigDir string) {
 	if len(registries) == 0 {
 		return
 	}
@@ -164,14 +185,16 @@ func (c *ComposeClient) loginToRegistries(ctx context.Context, registries []Regi
 		log.Debugf("Compose: Logging into registry %s", registryHost)
 
 		cmd := exec.CommandContext(ctx, "docker", "login", "-u", reg.Username, "--password-stdin", registryHost)
-		cmd.Env = append(os.Environ(), fmt.Sprintf("DOCKER_HOST=unix://%s", c.dockerSocket))
+		cmd.Env = c.dockerEnv(dockerConfigDir)
 		cmd.Stdin = strings.NewReader(reg.Password)
 
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 
 		if err := cmd.Run(); err != nil {
-			log.Debugf("Compose: Failed to login to %s: %s", registryHost, stderr.String())
+			// Surface at warn level: a failed login here is the usual cause of a
+			// later "unauthorized" pull, and is otherwise silently swallowed.
+			log.Warnf("Compose: Failed to login to %s: %s", registryHost, strings.TrimSpace(stderr.String()))
 		} else {
 			log.Debugf("Compose: Successfully logged into %s", registryHost)
 		}
@@ -189,9 +212,23 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 		}, nil
 	}
 
+	// Use an ephemeral Docker config under stacksDir so login and compose share
+	// credentials without writing to $HOME (unwritable under ProtectHome=true).
+	var dockerConfigDir string
+	if (op.Operation == "up" || op.Operation == "pull") && len(op.Registries) > 0 && c.stacksDir != "" {
+		if err := os.MkdirAll(c.stacksDir, 0755); err != nil {
+			log.Warnf("Compose: could not create stacks dir %s, registry auth may fail: %v", c.stacksDir, err)
+		} else if dir, err := os.MkdirTemp(c.stacksDir, ".docker-"); err == nil {
+			dockerConfigDir = dir
+			defer os.RemoveAll(dockerConfigDir)
+		} else {
+			log.Warnf("Compose: could not create docker config dir, registry auth may fail: %v", err)
+		}
+	}
+
 	// Login to registries before up/pull operations
 	if op.Operation == "up" || op.Operation == "pull" {
-		c.loginToRegistries(ctx, op.Registries)
+		c.loginToRegistries(ctx, op.Registries, dockerConfigDir)
 	}
 
 	// Build command arguments
@@ -445,20 +482,12 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 		cmd.Dir = op.WorkDir
 	}
 
-	// Set clean environment to prevent host env vars from overriding compose stack variables
-	cmd.Env = []string{
-		fmt.Sprintf("DOCKER_HOST=unix://%s", c.dockerSocket),
-	}
-	for _, key := range []string{"PATH", "HOME", "USER"} {
-		if val, ok := os.LookupEnv(key); ok {
-			cmd.Env = append(cmd.Env, key+"="+val)
-		}
-	}
-
-	// Set API version for compatibility with newer Docker daemons
-	// This allows older docker CLI to work with newer daemons
+	// Clean environment so host vars and the stack's own EnvVars (below) can't
+	// redirect docker. dockerConfigDir carries the credentials written by
+	// loginToRegistries; the user EnvVars loop rejects DOCKER_CONFIG
+	// (see deniedEnvKeys) and so cannot override it.
+	cmd.Env = c.dockerEnv(dockerConfigDir)
 	if c.apiVersion != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("DOCKER_API_VERSION=%s", c.apiVersion))
 		log.Debugf("Compose: Using API version %s", c.apiVersion)
 	}
 


### PR DESCRIPTION
## Problem

Deploying a stack that pulls a **private** image fails with:

```
Error response from daemon: Head "https://ghcr.io/v2/<org>/<image>/manifests/latest": unauthorized
```

even when the registry credentials are correct.

`ComposeClient.Execute` runs `docker login` (via `loginToRegistries`) and then `docker compose up`/`pull`. `docker login` persists credentials to `$HOME/.docker/config.json`, but the bundled systemd unit (`scripts/hawser.service`) hardens the agent with `ProtectHome=true`, which makes `$HOME` (`/root`) unwritable inside the service's mount namespace. As a result:

- `docker login` cannot persist the credentials (and the error was only logged at debug level, so it was invisible);
- the subsequent compose command — which is given a clean environment (commit 3cbc419) — finds no credentials and pulls anonymously → `unauthorized`.

This affects every private registry on a default install, not just GHCR. It reproduces reliably with the shipped unit; `docker login`/`docker compose` succeed only when run by hand outside the sandbox (where `/root/.docker` is visible).

## Fix

Give `docker login` and the compose command a shared, writable `DOCKER_CONFIG`:

- create an **ephemeral** `DOCKER_CONFIG` directory under `stacksDir` (already writable per the unit's `ReadWritePaths`) for `up`/`pull` operations that carry registry credentials, and `RemoveAll` it when the operation completes;
- pass that `DOCKER_CONFIG` to both `docker login` and the compose command through a small `dockerEnv` helper. The helper also gives `docker login` the same minimal, clean environment the compose command already uses, so host vars such as `DOCKER_CONTEXT`/`DOCKER_TLS_VERIFY` cannot redirect it;
- raise a failed `docker login` from debug to **warn**, since it is the usual root cause of a later unauthorized pull.

No systemd unit change is required.

## Notes / tradeoffs

- The credential file lives only for the duration of the operation, in a `0700` dir owned by root, and is removed via `defer`. On a hard crash/kill a `.docker-*` dir could linger; left as an accepted tradeoff to keep this change small (a sweep of stale dirs could be a follow-up).
- `stacksDir` is `MkdirAll`'d before use so custom installs without a pre-created stacks dir still work.
- The fix depends only on `stacksDir`, not on `$HOME`, so it also works for non-systemd deployments (e.g. the Docker image), including containers with a read-only root filesystem, where `$HOME/.docker` would be unwritable too. When `stacksDir` is unset the behaviour is unchanged.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` pass.
- Reproduced on a host running the agent with `ProtectHome=true`: a clean env with an unwritable `$HOME` makes `docker compose pull` of a private image fail with the exact `unauthorized` error; running `docker login` with an explicit shared `DOCKER_CONFIG` and then compose with the same `DOCKER_CONFIG` pulls successfully.
