### PR TITLE
Strip Dockhand control/selector env vars from compose injection

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -89,9 +89,10 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     RECONNECT_DELAY=1 \
     MAX_RECONNECT_DELAY=60
 
-# Create docker compose plugin symlink
+# Create docker compose plugin symlink.
+# Use ln -sf because newer docker-compose packages already ship this symlink.
 RUN mkdir -p /usr/libexec/docker/cli-plugins \
-    && ln -s /usr/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
+    && ln -sf /usr/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 
 # Copy binary from builder
 COPY --from=builder /hawser /usr/local/bin/hawser

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -19,6 +19,18 @@ import (
 // Rejects dangerous keys like LD_PRELOAD, PATH, DOCKER_HOST etc. via denylist below.
 var validEnvKeyRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
+// controlEnvKeys are Dockhand-internal control variables that drive server-side
+// secret resolution (e.g. bulk-pull selectors). Secret resolution happens
+// entirely on the Dockhand server, and these selectors should already be removed
+// from envVars before a deploy request reaches the agent. The agent strips them
+// defensively so they can never be injected into the compose process or leak into
+// a container if the server ever fails to remove them. Unlike deniedEnvKeys these
+// are stripped silently rather than failing the deploy.
+var controlEnvKeys = map[string]bool{
+	"DOCKHAND_SECRET_SELECTOR": true,
+	"OP_ENVIRONMENT_ID":        true,
+}
+
 // deniedEnvKeys are environment variable names that could be used for code execution
 // or to redirect Docker operations to an attacker-controlled endpoint.
 var deniedEnvKeys = map[string]bool{
@@ -54,6 +66,37 @@ func NewComposeClient(dockerSocket, stacksDir string) *ComposeClient {
 		dockerSocket: dockerSocket,
 		stacksDir:    stacksDir,
 	}
+}
+
+// buildComposeEnv validates and filters the caller-supplied environment variables
+// for a compose invocation and returns the "KEY=VALUE" entries to append to the
+// command environment. Resolved secrets arrive here (merged into envVars by
+// Dockhand) and are injected via the process environment only; values are never
+// logged. Invalid key names fail the operation; Dockhand control/selector
+// variables and dangerous keys are filtered out silently/with a warning and are
+// never returned.
+func buildComposeEnv(envVars map[string]string) ([]string, error) {
+	entries := make([]string, 0, len(envVars))
+	for key, value := range envVars {
+		// Validate env var key format (alphanumeric + underscore only)
+		if !validEnvKeyRegex.MatchString(key) {
+			return nil, fmt.Errorf("Invalid environment variable name: %q", key)
+		}
+		// Strip Dockhand control/selector variables so they never reach the
+		// compose process or leak into containers (defense in depth; the server
+		// resolves and removes these before dispatch).
+		if controlEnvKeys[strings.ToUpper(key)] {
+			log.Debugf("Compose: Stripping control variable from compose env: %s", key)
+			continue
+		}
+		// Block dangerous env vars that could enable code execution or redirect Docker
+		if deniedEnvKeys[strings.ToUpper(key)] {
+			log.Warnf("Compose: Blocked dangerous environment variable: %s", key)
+			continue
+		}
+		entries = append(entries, fmt.Sprintf("%s=%s", key, value))
+	}
+	return entries, nil
 }
 
 // SetAPIVersion sets the Docker API version to use for compose commands.
@@ -462,23 +505,19 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 		log.Debugf("Compose: Using API version %s", c.apiVersion)
 	}
 
-	// Add environment variables for compose variable substitution
-	for key, value := range op.EnvVars {
-		// Validate env var key format (alphanumeric + underscore only)
-		if !validEnvKeyRegex.MatchString(key) {
-			return &ComposeResult{
-				Success:  false,
-				Error:    fmt.Sprintf("Invalid environment variable name: %q", key),
-				ExitCode: 1,
-			}, nil
-		}
-		// Block dangerous env vars that could enable code execution or redirect Docker
-		if deniedEnvKeys[strings.ToUpper(key)] {
-			log.Warnf("Compose: Blocked dangerous environment variable: %s", key)
-			continue
-		}
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	// Add environment variables for compose variable substitution.
+	// These include resolved secrets (secretVars merged into envVars by Dockhand):
+	// they are injected into the compose process environment only and are never
+	// logged or written to disk here. Only key names are ever logged, not values.
+	envEntries, envErr := buildComposeEnv(op.EnvVars)
+	if envErr != nil {
+		return &ComposeResult{
+			Success:  false,
+			Error:    envErr.Error(),
+			ExitCode: 1,
+		}, nil
 	}
+	cmd.Env = append(cmd.Env, envEntries...)
 
 	// Log the command being executed
 	log.Debugf("Compose: %s %s (project=%s)", c.composeCmd, strings.Join(fullArgs, " "), op.ProjectName)

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -1,0 +1,131 @@
+package docker
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestBuildComposeEnv_InjectsSecrets verifies that resolved secret env vars
+// (merged into envVars by Dockhand) are injected into the compose process env.
+func TestBuildComposeEnv_InjectsSecrets(t *testing.T) {
+	entries, err := buildComposeEnv(map[string]string{
+		"SECRET_CHECK": "resolved-secret-value",
+		"DB_PASSWORD":  "hunter2",
+		"APP_ENV":      "production",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := envMap(entries)
+	for k, want := range map[string]string{
+		"SECRET_CHECK": "resolved-secret-value",
+		"DB_PASSWORD":  "hunter2",
+		"APP_ENV":      "production",
+	} {
+		if got[k] != want {
+			t.Errorf("env %q = %q, want %q", k, got[k], want)
+		}
+	}
+}
+
+// TestBuildComposeEnv_StripsControlVars verifies that Dockhand control/selector
+// variables are stripped and never injected (doc task 5: bulk-pull selector must
+// not leak into the container), while sibling vars are still injected.
+func TestBuildComposeEnv_StripsControlVars(t *testing.T) {
+	entries, err := buildComposeEnv(map[string]string{
+		"DOCKHAND_SECRET_SELECTOR": "prod/app",
+		"OP_ENVIRONMENT_ID":        "env_123",
+		"PULLED_KEY":               "pulled-value",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := envMap(entries)
+	if _, ok := got["DOCKHAND_SECRET_SELECTOR"]; ok {
+		t.Error("DOCKHAND_SECRET_SELECTOR was injected; it must be stripped")
+	}
+	if _, ok := got["OP_ENVIRONMENT_ID"]; ok {
+		t.Error("OP_ENVIRONMENT_ID was injected; it must be stripped")
+	}
+	if got["PULLED_KEY"] != "pulled-value" {
+		t.Errorf("PULLED_KEY = %q, want %q", got["PULLED_KEY"], "pulled-value")
+	}
+}
+
+// TestBuildComposeEnv_StripsControlVarsCaseInsensitive verifies control-var
+// stripping is case-insensitive (env keys can arrive in any case).
+func TestBuildComposeEnv_StripsControlVarsCaseInsensitive(t *testing.T) {
+	entries, err := buildComposeEnv(map[string]string{
+		"dockhand_secret_selector": "prod/app",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected control var stripped, got entries: %v", entries)
+	}
+}
+
+// TestBuildComposeEnv_BlocksDangerousKeys verifies code-execution / Docker-redirect
+// vars are dropped rather than injected.
+func TestBuildComposeEnv_BlocksDangerousKeys(t *testing.T) {
+	for _, key := range []string{"LD_PRELOAD", "PATH", "DOCKER_HOST", "BASH_ENV"} {
+		entries, err := buildComposeEnv(map[string]string{
+			key:      "malicious",
+			"SAFE_K": "ok",
+		})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", key, err)
+		}
+		got := envMap(entries)
+		if _, ok := got[key]; ok {
+			t.Errorf("dangerous key %q was injected; it must be blocked", key)
+		}
+		if got["SAFE_K"] != "ok" {
+			t.Errorf("%s: SAFE_K = %q, want ok", key, got["SAFE_K"])
+		}
+	}
+}
+
+// TestBuildComposeEnv_RejectsInvalidKeyNames verifies key-format validation rejects
+// injection-style names, matching the previous inline behavior.
+func TestBuildComposeEnv_RejectsInvalidKeyNames(t *testing.T) {
+	for _, key := range []string{"BAD KEY", "KEY=INJECT", "9LEADING", "has-dash", ""} {
+		_, err := buildComposeEnv(map[string]string{key: "v"})
+		if err == nil {
+			t.Errorf("expected error for invalid key %q, got nil", key)
+		}
+	}
+}
+
+// TestBuildComposeEnv_PreservesValueWithEquals verifies that values containing "="
+// (common in tokens/base64 secrets) survive intact.
+func TestBuildComposeEnv_PreservesValueWithEquals(t *testing.T) {
+	entries, err := buildComposeEnv(map[string]string{
+		"TOKEN": "abc=def==",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := envMap(entries)
+	if got["TOKEN"] != "abc=def==" {
+		t.Errorf("TOKEN = %q, want %q", got["TOKEN"], "abc=def==")
+	}
+}
+
+// envMap splits "KEY=VALUE" entries into a map, splitting on the first '='.
+func envMap(entries []string) map[string]string {
+	m := make(map[string]string, len(entries))
+	sort.Strings(entries)
+	for _, e := range entries {
+		k, v, found := strings.Cut(e, "=")
+		if !found {
+			continue
+		}
+		m[k] = v
+	}
+	return m
+}


### PR DESCRIPTION
## Summary

Hardens the agent's handling of resolved secrets for `hawser-edge` deployments and
adds the first unit tests for the compose env-injection path.

Dockhand resolves secrets server-side and sends them merged into the deploy
request's `envVars` map. The agent injects those into the `docker compose` child
process environment. This change ensures Dockhand's bulk-pull control variables
(`DOCKHAND_SECRET_SELECTOR`, `OP_ENVIRONMENT_ID`) are never injected into the compose
process or a container, even when the server leaves them in the request.

## Motivation

Dockhand strips the selector variable from outgoing vars only on the successful
bulk-resolution path (`resolveProviderEnvVars` in `src/lib/server/stacks.ts`). In
three misconfiguration cases (no provider bound, unregistered provider type, or a
provider without bulk support), the server logs a warning and leaves the selector
variable in `envVars`, which is then dispatched to the agent. Without agent-side
handling, that selector would be injected into the deployed container.

The selector names match Dockhand's `BULK_SELECTOR_VARS`
(`['DOCKHAND_SECRET_SELECTOR', 'OP_ENVIRONMENT_ID']`).

## Changes

- `internal/docker/compose.go`
  - Add `controlEnvKeys` denylist for Dockhand control/selector variables.
  - Extract the env-injection loop from `Execute` into a testable `buildComposeEnv`
    helper that validates key names, strips control/selector variables, drops
    dangerous keys, and returns the entries to append to `cmd.Env`.
  - `Execute` now calls the helper. Behavior for valid, invalid, and dangerous keys
    is unchanged.
- `internal/docker/compose_test.go` (new)
  - Unit tests: secret injection, selector stripping (including case-insensitive),
    dangerous-key blocking, invalid-key rejection, and preservation of values that
    contain `=`.
- `Dockerfile.dev`
  - Use `ln -sf` for the compose cli-plugin symlink. The current Wolfi
    `docker-compose` package already ships the symlink, so `ln -s` fails the build
    with "File exists". This matches the existing fix in the production `Dockerfile`.

## Behavior

- Resolved secrets continue to be injected into the compose process environment
  only. They are not written to disk and their values are not logged.
- `DOCKHAND_SECRET_SELECTOR` and `OP_ENVIRONMENT_ID` are stripped before injection,
  unconditionally and case-insensitively, at debug log level.
- Existing key validation and the `deniedEnvKeys` denylist are preserved.

## Testing

- `go vet ./...`, `go build ./...`, and `go test ./...` all pass (run in a
  `golang:1.26` container).
- New `TestBuildComposeEnv_*` cases cover the injection and stripping logic.
- Built a `linux/arm64` image from `Dockerfile.dev` and confirmed the binary runs and
  `docker compose` resolves inside the image.
- End-to-end leak check with a canary secret on a hawser-edge deployment: the
  container receives the resolved value, no selector variables reach the container,
  and the canary appears in no `.env`, no stack file, and no agent log.

## Risk and compatibility

- No wire-format or API change. `ComposeOperation` is unchanged.
- No change to how legitimate application env vars or secrets are injected.
- The only new behavior is dropping two Dockhand-internal control variables that are
  not intended to reach containers. If a stack legitimately needed a variable named
  `DOCKHAND_SECRET_SELECTOR` or `OP_ENVIRONMENT_ID` in its container (not a supported
  use), it would no longer receive it.

## Checklist

- [x] `go vet`, `go build`, `go test` pass
- [x] New unit tests added
- [x] No changes to the request/response contract
- [x] Docs/comments updated in-code
