### PR TITLE
Companion for dockhand PR #1323

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -22,20 +22,20 @@ var validEnvKeyRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 // deniedEnvKeys are environment variable names that could be used for code execution
 // or to redirect Docker operations to an attacker-controlled endpoint.
 var deniedEnvKeys = map[string]bool{
-	"LD_PRELOAD":      true,
-	"LD_LIBRARY_PATH": true,
-	"PATH":            true,
-	"DOCKER_HOST":     true,
-	"DOCKER_CONFIG":   true,
-	"DOCKER_CERT_PATH": true,
+	"LD_PRELOAD":        true,
+	"LD_LIBRARY_PATH":   true,
+	"PATH":              true,
+	"DOCKER_HOST":       true,
+	"DOCKER_CONFIG":     true,
+	"DOCKER_CERT_PATH":  true,
 	"DOCKER_TLS_VERIFY": true,
-	"DOCKER_CONTEXT":  true,
-	"HOME":            true,
-	"SHELL":           true,
-	"BASH_ENV":        true,
-	"ENV":             true,
-	"CDPATH":          true,
-	"IFS":             true,
+	"DOCKER_CONTEXT":    true,
+	"HOME":              true,
+	"SHELL":             true,
+	"BASH_ENV":          true,
+	"ENV":               true,
+	"CDPATH":            true,
+	"IFS":               true,
 }
 
 // ComposeClient handles Docker Compose operations
@@ -101,24 +101,25 @@ type RegistryCredentials struct {
 
 // ComposeOperation represents a compose operation request
 type ComposeOperation struct {
-	Operation       string                `json:"operation"` // up, down, pull, ps, logs
-	ProjectName     string                `json:"projectName"`
-	WorkDir         string                `json:"workDir"`
-	ComposeFile     string                `json:"composeFile,omitempty"`     // Content of compose file
-	ComposeFileName string                `json:"composeFileName,omitempty"` // Explicit compose filename to use (e.g., "docker-compose.prod.yml")
-	Files           map[string]string     `json:"files,omitempty"`           // All files to write (relative path -> content)
-	Services        []string              `json:"services,omitempty"`        // Specific services to operate on
-	Options         map[string]string     `json:"options,omitempty"`         // Additional options
-	EnvVars         map[string]string     `json:"envVars,omitempty"`         // Environment variables for variable substitution
-	Registries      []RegistryCredentials `json:"registries,omitempty"`      // Registry credentials for docker login
-	ForceRecreate   bool                  `json:"forceRecreate,omitempty"`   // Force recreation of containers (--force-recreate)
-	RemoveVolumes   bool                  `json:"removeVolumes,omitempty"`   // Remove volumes on down (--volumes)
-	ServiceName     string                `json:"serviceName,omitempty"`     // Target specific service only (with --no-deps)
-	Build           bool                  `json:"build,omitempty"`           // Build images before starting (--build)
-	NoBuildCache    bool                  `json:"noBuildCache,omitempty"`    // Build without cache (--no-cache)
-	PullPolicy      string                `json:"pullPolicy,omitempty"`      // Pull policy: 'always' | 'missing' | 'never'
-	FilesToDelete   []FileToDelete        `json:"filesToDelete,omitempty"`   // Git deletion sync (#966): hash-verified file removals
-	RemoveFiles     bool                  `json:"removeFiles,omitempty"`     // On down: remove the stack directory entirely (#1162, stack deletion only)
+	Operation        string                `json:"operation"` // up, down, pull, ps, logs
+	ProjectName      string                `json:"projectName"`
+	WorkDir          string                `json:"workDir"`
+	ComposeFile      string                `json:"composeFile,omitempty"`      // Content of compose file
+	ComposeFileName  string                `json:"composeFileName,omitempty"`  // Explicit compose filename (single -f; e.g. "docker-compose.prod.yml")
+	ComposeFileNames []string              `json:"composeFileNames,omitempty"` // Ordered compose filenames for multi -f (Dockhand multi-file / overrides)
+	Files            map[string]string     `json:"files,omitempty"`            // All files to write (relative path -> content)
+	Services         []string              `json:"services,omitempty"`         // Specific services to operate on
+	Options          map[string]string     `json:"options,omitempty"`          // Additional options
+	EnvVars          map[string]string     `json:"envVars,omitempty"`          // Environment variables for variable substitution
+	Registries       []RegistryCredentials `json:"registries,omitempty"`       // Registry credentials for docker login
+	ForceRecreate    bool                  `json:"forceRecreate,omitempty"`    // Force recreation of containers (--force-recreate)
+	RemoveVolumes    bool                  `json:"removeVolumes,omitempty"`    // Remove volumes on down (--volumes)
+	ServiceName      string                `json:"serviceName,omitempty"`      // Target specific service only (with --no-deps)
+	Build            bool                  `json:"build,omitempty"`            // Build images before starting (--build)
+	NoBuildCache     bool                  `json:"noBuildCache,omitempty"`     // Build without cache (--no-cache)
+	PullPolicy       string                `json:"pullPolicy,omitempty"`       // Pull policy: 'always' | 'missing' | 'never'
+	FilesToDelete    []FileToDelete        `json:"filesToDelete,omitempty"`    // Git deletion sync (#966): hash-verified file removals
+	RemoveFiles      bool                  `json:"removeFiles,omitempty"`      // On down: remove the stack directory entirely (#1162, stack deletion only)
 }
 
 // ComposeResult is the result of a compose operation
@@ -131,6 +132,80 @@ type ComposeResult struct {
 	// exactly one of these — Dockhand uses their presence to detect support.
 	DeletedFiles []string      `json:"deletedFiles,omitempty"`
 	SkippedFiles []SkippedFile `json:"skippedFiles,omitempty"`
+}
+
+// composeFileAbsPath joins stackDir with a relative compose path after validating
+// it cannot escape the stack directory. Returns absolute path or an error message.
+func composeFileAbsPath(stackDir, relPath string) (string, string) {
+	if !isSafeRelPath(relPath) {
+		return "", fmt.Sprintf("Invalid compose file path: %q", relPath)
+	}
+	absPath, err := filepath.Abs(filepath.Join(stackDir, filepath.FromSlash(relPath)))
+	if err != nil {
+		return "", fmt.Sprintf("Failed to resolve compose file path %q: %v", relPath, err)
+	}
+	if !strings.HasPrefix(absPath, stackDir+string(os.PathSeparator)) && absPath != stackDir {
+		return "", fmt.Sprintf("Path traversal rejected: %s escapes stack directory", relPath)
+	}
+	return absPath, ""
+}
+
+// resolveComposeFileFlags builds ordered docker compose -f flag pairs for a stack.
+//
+// Precedence:
+//  1. ComposeFileNames — multi-file / override list from Dockhand (multiple -f)
+//  2. ComposeFileName — single explicit file (backward compatible)
+//  3. Auto-detect standard filenames present in Files
+//  4. ComposeFile content — caller writes docker-compose.yml (fallbackPath set)
+//
+// Returns (flagPairs, fallbackWritePath, errMsg). When fallbackWritePath is non-empty,
+// the caller must write op.ComposeFile there before running compose.
+func resolveComposeFileFlags(stackDir string, op *ComposeOperation) (flags []string, fallbackPath string, errMsg string) {
+	appendFile := func(rel string) string {
+		abs, msg := composeFileAbsPath(stackDir, rel)
+		if msg != "" {
+			return msg
+		}
+		flags = append(flags, "-f", abs)
+		log.Debugf("Compose: Using compose file: %s", rel)
+		return ""
+	}
+
+	if len(op.ComposeFileNames) > 0 {
+		for _, name := range op.ComposeFileNames {
+			if name == "" {
+				return nil, "", "composeFileNames contains an empty path"
+			}
+			if msg := appendFile(name); msg != "" {
+				return nil, "", msg
+			}
+		}
+		return flags, "", ""
+	}
+
+	if op.ComposeFileName != "" {
+		if msg := appendFile(op.ComposeFileName); msg != "" {
+			return nil, "", msg
+		}
+		return flags, "", ""
+	}
+
+	for _, name := range []string{"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"} {
+		if _, exists := op.Files[name]; exists {
+			if msg := appendFile(name); msg != "" {
+				return nil, "", msg
+			}
+			return flags, "", ""
+		}
+	}
+
+	if op.ComposeFile != "" {
+		fallbackPath = filepath.Join(stackDir, "docker-compose.yml")
+		flags = append(flags, "-f", fallbackPath)
+		return flags, fallbackPath, ""
+	}
+
+	return nil, "", ""
 }
 
 // loginToRegistries logs into all provided registries before compose operations
@@ -291,38 +366,24 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 
 		log.Debugf("Compose: Wrote %d files to %s", len(op.Files), stackDir)
 
-		// Determine compose file name:
-		// 1. If ComposeFileName is explicitly provided, use it
-		// 2. Otherwise, auto-detect from standard filenames
-		composeFileName := ""
-		if op.ComposeFileName != "" {
-			// Explicit compose filename provided - use it directly
-			composeFileName = op.ComposeFileName
-			log.Debugf("Compose: Using explicit compose filename: %s", composeFileName)
-		} else {
-			// Auto-detect compose file from written files
-			for _, name := range []string{"docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"} {
-				if _, exists := op.Files[name]; exists {
-					composeFileName = name
-					break
-				}
-			}
+		fileFlags, fallbackPath, errMsg := resolveComposeFileFlags(stackDir, op)
+		if errMsg != "" {
+			return &ComposeResult{
+				Success:  false,
+				Error:    errMsg,
+				ExitCode: 1,
+			}, nil
 		}
-
-		if composeFileName != "" {
-			args = append(args, "-f", filepath.Join(stackDir, composeFileName))
-		} else if op.ComposeFile != "" {
-			// Fallback: write compose content to docker-compose.yml
-			composePath := filepath.Join(stackDir, "docker-compose.yml")
-			if err := os.WriteFile(composePath, []byte(op.ComposeFile), 0644); err != nil {
+		if fallbackPath != "" {
+			if err := os.WriteFile(fallbackPath, []byte(op.ComposeFile), 0644); err != nil {
 				return &ComposeResult{
 					Success:  false,
 					Error:    fmt.Sprintf("Failed to write compose file: %v", err),
 					ExitCode: 1,
 				}, nil
 			}
-			args = append(args, "-f", composePath)
 		}
+		args = append(args, fileFlags...)
 	} else if op.ComposeFile != "" {
 		// LEGACY: stdin-based approach (no files provided)
 		stdinContent = op.ComposeFile

--- a/internal/docker/compose_files_test.go
+++ b/internal/docker/compose_files_test.go
@@ -1,0 +1,147 @@
+package docker
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveComposeFileFlags_MultiFile(t *testing.T) {
+	stackDir := t.TempDir()
+	op := &ComposeOperation{
+		ComposeFileNames: []string{"apps/web/compose.yaml", "apps/web/compose.override.yaml"},
+		Files: map[string]string{
+			"apps/web/compose.yaml":          "services: {}",
+			"apps/web/compose.override.yaml": "services: {}",
+		},
+	}
+
+	flags, fallback, errMsg := resolveComposeFileFlags(stackDir, op)
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if fallback != "" {
+		t.Fatalf("expected no fallback path, got %q", fallback)
+	}
+	if len(flags) != 4 {
+		t.Fatalf("expected 4 flag args (-f path x2), got %v", flags)
+	}
+	if flags[0] != "-f" || flags[2] != "-f" {
+		t.Fatalf("expected alternating -f flags, got %v", flags)
+	}
+	if !strings.HasSuffix(flags[1], filepath.FromSlash("apps/web/compose.yaml")) {
+		t.Fatalf("first -f path = %q", flags[1])
+	}
+	if !strings.HasSuffix(flags[3], filepath.FromSlash("apps/web/compose.override.yaml")) {
+		t.Fatalf("second -f path = %q", flags[3])
+	}
+}
+
+func TestResolveComposeFileFlags_PrefersNamesOverSingular(t *testing.T) {
+	stackDir := t.TempDir()
+	op := &ComposeOperation{
+		ComposeFileName:  "ignored.yaml",
+		ComposeFileNames: []string{"compose.yaml", "extra.yaml"},
+		Files:            map[string]string{"compose.yaml": "x", "extra.yaml": "y"},
+	}
+
+	flags, _, errMsg := resolveComposeFileFlags(stackDir, op)
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if len(flags) != 4 {
+		t.Fatalf("expected multi -f from ComposeFileNames, got %v", flags)
+	}
+	if strings.Contains(flags[1], "ignored.yaml") {
+		t.Fatalf("ComposeFileName should be ignored when ComposeFileNames is set: %v", flags)
+	}
+}
+
+func TestResolveComposeFileFlags_SingularFallback(t *testing.T) {
+	stackDir := t.TempDir()
+	op := &ComposeOperation{
+		ComposeFileName: "apps/api/compose.yaml",
+	}
+
+	flags, fallback, errMsg := resolveComposeFileFlags(stackDir, op)
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if fallback != "" {
+		t.Fatalf("unexpected fallback %q", fallback)
+	}
+	if len(flags) != 2 || flags[0] != "-f" {
+		t.Fatalf("expected single -f pair, got %v", flags)
+	}
+	if !strings.HasSuffix(flags[1], filepath.FromSlash("apps/api/compose.yaml")) {
+		t.Fatalf("path = %q", flags[1])
+	}
+}
+
+func TestResolveComposeFileFlags_AutoDetect(t *testing.T) {
+	stackDir := t.TempDir()
+	op := &ComposeOperation{
+		Files: map[string]string{"compose.yaml": "services: {}"},
+	}
+
+	flags, _, errMsg := resolveComposeFileFlags(stackDir, op)
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if len(flags) != 2 || !strings.HasSuffix(flags[1], "compose.yaml") {
+		t.Fatalf("expected auto-detect compose.yaml, got %v", flags)
+	}
+}
+
+func TestResolveComposeFileFlags_ContentFallback(t *testing.T) {
+	stackDir := t.TempDir()
+	op := &ComposeOperation{
+		ComposeFile: "services: {}",
+	}
+
+	flags, fallback, errMsg := resolveComposeFileFlags(stackDir, op)
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if fallback == "" {
+		t.Fatal("expected fallback write path")
+	}
+	if len(flags) != 2 || flags[1] != fallback {
+		t.Fatalf("flags=%v fallback=%q", flags, fallback)
+	}
+}
+
+func TestResolveComposeFileFlags_RejectsTraversal(t *testing.T) {
+	stackDir := t.TempDir()
+	op := &ComposeOperation{
+		ComposeFileNames: []string{"../escape.yaml"},
+	}
+
+	_, _, errMsg := resolveComposeFileFlags(stackDir, op)
+	if errMsg == "" {
+		t.Fatal("expected path traversal error")
+	}
+}
+
+func TestResolveComposeFileFlags_RejectsEmptyName(t *testing.T) {
+	stackDir := t.TempDir()
+	op := &ComposeOperation{
+		ComposeFileNames: []string{"compose.yaml", ""},
+	}
+
+	_, _, errMsg := resolveComposeFileFlags(stackDir, op)
+	if errMsg == "" {
+		t.Fatal("expected empty path error")
+	}
+}
+
+func TestComposeFileAbsPath_SafeNested(t *testing.T) {
+	stackDir := t.TempDir()
+	abs, errMsg := composeFileAbsPath(stackDir, "apps/web/compose.yaml")
+	if errMsg != "" {
+		t.Fatalf("unexpected error: %s", errMsg)
+	}
+	if !strings.HasPrefix(abs, stackDir) {
+		t.Fatalf("abs path %q not under stackDir %q", abs, stackDir)
+	}
+}

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -261,6 +261,7 @@ func (c *Client) sendHello() error {
 		hostname,
 		hawserVersion,
 		capabilities,
+		c.cfg.StacksDir,
 	)
 
 	return c.sendJSON(hello)
@@ -462,6 +463,12 @@ func (c *Client) handleRequest(req *protocol.RequestMessage) {
 		return
 	}
 
+	// Agent info (same shape as standard mode so Dockhand can read STACKS_DIR)
+	if req.Path == "/_hawser/info" {
+		c.handleInfoRequest(ctx, req)
+		return
+	}
+
 	// Make Docker request
 	var body io.Reader
 	if len(req.Body) > 0 {
@@ -573,6 +580,34 @@ func (c *Client) handleStreamingRequest(req *protocol.RequestMessage, headers ma
 			return
 		}
 	}
+}
+
+// handleInfoRequest returns agent information (mirrors standard mode /_hawser/info)
+func (c *Client) handleInfoRequest(ctx context.Context, req *protocol.RequestMessage) {
+	version, _ := c.dockerClient.GetVersion(ctx)
+
+	dockerVersion := "unknown"
+	if version != nil {
+		dockerVersion = version.Version
+	}
+
+	hawserVersion := c.cfg.Version
+	if hawserVersion == "" {
+		hawserVersion = "dev"
+	}
+
+	respBody, _ := json.Marshal(map[string]interface{}{
+		"agentId":       c.cfg.AgentID,
+		"agentName":     c.cfg.AgentName,
+		"dockerVersion": dockerVersion,
+		"hawserVersion": hawserVersion,
+		"mode":          "edge",
+		"uptime":        getHostUptime(),
+		"stacksDir":     c.cfg.StacksDir,
+		"capabilities":  []string{"exec", "metrics", "events", "compose", "git-sync-delete"},
+	})
+
+	c.sendJSON(protocol.NewResponseMessage(req.RequestID, http.StatusOK, nil, respBody))
 }
 
 // handleComposeRequest handles Docker Compose operations
@@ -1187,4 +1222,24 @@ func (c *Client) startHealthServer() {
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Warnf("Health server error: %v", err)
 	}
+}
+
+// getHostUptime reads host uptime from /proc/uptime (Linux only)
+func getHostUptime() uint64 {
+	file, err := os.Open("/proc/uptime")
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 1 {
+			var uptime float64
+			fmt.Sscanf(fields[0], "%f", &uptime)
+			return uint64(uptime)
+		}
+	}
+	return 0
 }

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -58,10 +58,11 @@ type HelloMessage struct {
 	DockerVersion string   `json:"dockerVersion"`
 	Hostname      string   `json:"hostname"`
 	Capabilities  []string `json:"capabilities"`
+	StacksDir     string   `json:"stacksDir,omitempty"` // Remote STACKS_DIR where compose stacks are written
 }
 
 // NewHelloMessage creates a new hello message
-func NewHelloMessage(agentID, agentName, token, tokenHash, dockerVersion, hostname, hawserVersion string, capabilities []string) *HelloMessage {
+func NewHelloMessage(agentID, agentName, token, tokenHash, dockerVersion, hostname, hawserVersion string, capabilities []string, stacksDir string) *HelloMessage {
 	return &HelloMessage{
 		Type:          TypeHello,
 		Version:       hawserVersion,
@@ -73,6 +74,7 @@ func NewHelloMessage(agentID, agentName, token, tokenHash, dockerVersion, hostna
 		DockerVersion: dockerVersion,
 		Hostname:      hostname,
 		Capabilities:  capabilities,
+		StacksDir:     stacksDir,
 	}
 }
 

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -514,6 +514,7 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 		"hawserVersion": hawserVersion,
 		"mode":          "standard",
 		"uptime":        uptime,
+		"stacksDir":     s.cfg.StacksDir,
 		"capabilities":  []string{"exec", "metrics", "events", "compose", "git-sync-delete"},
 	})
 }


### PR DESCRIPTION
Commit 1 — 9e09dc3:
feat: support ordered multi-file compose (-f)

Add ComposeFileNames alongside ComposeFileName; resolve -f flags by
precedence (list → single → auto-detect → content fallback) and reject
paths escaping the stack dir.

Commit 2 — 3b2e735:
feat: report STACKS_DIR to Dockhand

Expose stacksDir via /_hawser/info (standard + edge) and the hello
message; add getHostUptime() for the edge info response.