### PR TITLE
Add Debian package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,6 +93,51 @@ docker_manifests:
       - "ghcr.io/finsys/hawser:latest-arm64"
       - "ghcr.io/finsys/hawser:latest-armv7"
 
+nfpms:
+  - id: hawser
+    package_name: hawser
+    description: |-
+      Remote Docker agent for Dockhand
+      Hawser lets a Dockhand server manage remote Docker hosts over HTTP or
+      outbound WebSocket connections.
+    maintainer: Finsys / Jarek Krochmalski <support@dockhand.pro>
+    section: net
+    homepage: https://dockhand.pro/
+    ids:
+      - hawser
+    formats:
+      - deb
+    dependencies:
+      - docker-ce
+      - libc6
+    contents:
+      - src: ./debian/hawser.service
+        dst: /usr/lib/systemd/system/hawser.service
+        packager: deb
+      - src: ./debian/copyright
+        dst: /usr/share/doc/hawser/copyright
+        packager: deb
+    scripts:
+      postinstall: ./debian/postinstall.sh
+      preremove: ./debian/prerm.sh
+      postremove: ./debian/postrm.sh
+    deb:
+      predepends:
+        - adduser
+        - debconf
+      scripts:
+        templates: ./debian/templates
+        config: ./debian/config.sh
+      lintian_overrides:
+        # Go release binaries are intentionally self-contained.
+        - statically-linked-binary
+        # A Debian changelog has not been written yet.
+        - no-changelog
+        # A manpage has not been written yet.
+        - no-manual-page
+        # GoReleaser 2.17 emits this field but cannot currently disable it.
+        - unknown-field Architecture-Variant
+
 checksum:
   name_template: "checksums.txt"
 

--- a/debian/config.sh
+++ b/debian/config.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+. /usr/share/debconf/confmodule
+db_version 2.0
+
+db_input high hawser/bind_address || true
+db_input high hawser/port || true
+db_input high hawser/token || true
+db_go

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,8 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Hawser
+Upstream-Contact: Finsys / Jarek Krochmalski <support@dockhand.pro>
+Source: https://dockhand.pro/
+
+Files: *
+Copyright: 2025-2026 Finsys / Jarek Krochmalski
+License: MIT

--- a/debian/hawser.service
+++ b/debian/hawser.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Hawser - Remote Docker Agent for Dockhand
+Documentation=https://github.com/Finsys/hawser
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/hawser
+Restart=always
+RestartSec=10
+EnvironmentFile=/etc/hawser/config
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hawser
+
+# Security hardening (relaxed for Docker access)
+NoNewPrivileges=false
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/run/docker.sock /data/stacks
+
+# Resource limits
+LimitNOFILE=65535
+LimitNPROC=4096
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/postinstall.sh
+++ b/debian/postinstall.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+[ "$1" = "configure" ] || exit 0
+
+. /usr/share/debconf/confmodule
+
+CONFIG_FILE=/etc/hawser/config
+CONFIG_DIR=/etc/hawser
+SERVICE=hawser
+SERVICE_USER=hawser
+
+# Create group and user
+if ! getent group "$SERVICE_USER" >/dev/null; then
+	echo "Creating $SERVICE_USER group"
+	addgroup --quiet --system "$SERVICE_USER"
+fi
+
+if ! getent passwd "$SERVICE_USER" >/dev/null; then
+	echo "Creating $SERVICE_USER user"
+	adduser --quiet --system "$SERVICE_USER" \
+		--ingroup "$SERVICE_USER" \
+		--no-create-home \
+		--home /nonexistent \
+		--gecos "System user for $SERVICE"
+fi
+
+# Add user to Docker group so it can use the socket
+adduser "$SERVICE_USER" docker || true
+
+# Create config file if it doesn't already exist
+if [ ! -f "$CONFIG_FILE" ]; then
+  install -d -m 0750 -o root -g "$SERVICE_USER" "$CONFIG_DIR"
+  {
+    echo "# Hawser Configuration"
+    echo "# See https://github.com/Finsys/hawser for documentation" 
+    echo 
+    echo "DOCKER_SOCKET=/run/docker.sock" 
+  } > "$CONFIG_FILE"
+	chmod 0600 "$CONFIG_FILE"
+	chown "$SERVICE_USER":"$SERVICE_USER" "$CONFIG_FILE"
+fi;
+
+# Add missing configs
+if ! grep -q "^BIND_ADDRESS=" "$CONFIG_FILE"; then
+  db_get hawser/bind_address
+  echo "BIND_ADDRESS=$RET" >> "$CONFIG_FILE"
+fi;
+
+if ! grep -q "^PORT=" "$CONFIG_FILE"; then
+  db_get hawser/port
+  echo "PORT=$RET" >> "$CONFIG_FILE"
+fi;
+
+if ! grep -q "^TOKEN=" "$CONFIG_FILE"; then
+  db_get hawser/token
+  echo "TOKEN=$RET" >> "$CONFIG_FILE"
+fi;
+
+deb-systemd-helper enable "$SERVICE".service
+systemctl daemon-reload
+deb-systemd-invoke start "$SERVICE".service || echo "could not start $SERVICE.service!"

--- a/debian/postrm.sh
+++ b/debian/postrm.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "purge" ]; then
+	. /usr/share/debconf/confmodule
+	db_purge
+	rm -f /etc/hawser/config
+	rmdir /etc/hawser 2>/dev/null || true
+fi

--- a/debian/prerm.sh
+++ b/debian/prerm.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+SERVICE=hawser
+
+deb-systemd-invoke stop "$SERVICE".service
+if [ "$1" = "remove" ]; then
+	deb-systemd-helper purge "$SERVICE".service
+fi

--- a/debian/templates
+++ b/debian/templates
@@ -1,0 +1,18 @@
+Template: hawser/bind_address
+Type: string
+Description: Listening address:
+ IP address on which Hawser should accept connections.
+ .
+ Leave this empty to listen on all addresses.
+
+Template: hawser/port
+Type: string
+Default: 2376
+Description: Listening TCP port:
+ TCP port on which Hawser should accept connections.
+
+Template: hawser/token
+Type: password
+Description: Authentication token:
+ Token clients must provide when connecting to Hawser. A token is required
+ when listening on a non-loopback address.


### PR DESCRIPTION
Updates the GoReleaser config to generate a Debian package as part of the build.

The Debian package:
1. Prompts for bind address, port, and token. Support for edge mode can be added as a followup.
2. Creates a `hawser` user and group.
3. Adds the `hawser` user to the `docker` group so it can access the socket.
4. Creates a config file based on the answers to the questions.

This is still a draft because I need to test/change a few things:
 - Randomly generate authentication token if it's left blank during package configuration.
 - Harden the systemd unit a bit more.
 - Test on Ubuntu. So far I've just tested on a base Debian + Docker installation.
 - Test on a VM. I've just tested on LXC so far, and LXC disables some of the security settings in systemd units since they don't work properly. Need to test in a VM to ensure the systemd unit works properly.
 - Add GitHub Action for full E2E test (build package, install package, verify it runs properly)

# Test Plan
Run the build:
```
goreleaser release --snapshot --clean
```
Create fresh Debian LXC container
Install Docker
Install the package:
```
root@debiantest2:/mnt/debian-temp# apt install ./hawser_0.0.0-SNAPSHOT-9967fa8_linux_amd64.deb 
Installing:
  hawser

Summary:
  Upgrading: 0, Installing: 1, Removing: 0, Not Upgrading: 0
  Download size: 0 B / 3,315 kB
  Space needed: 7,816 kB / 704 GB available

Get:1 /mnt/debian-temp/hawser_0.0.0-SNAPSHOT-9967fa8_linux_amd64.deb hawser amd64 0.0.0~SNAPSHOT-9967fa8 [3,315 kB]
Preconfiguring packages ...  
Selecting previously unselected package hawser.
(Reading database ... 34533 files and directories currently installed.)
Preparing to unpack .../hawser_0.0.0-SNAPSHOT-9967fa8_linux_amd64.deb ...
Unpacking hawser (0.0.0~SNAPSHOT-9967fa8) ...
Setting up hawser (0.0.0~SNAPSHOT-9967fa8) ...
Created symlink '/etc/systemd/system/multi-user.target.wants/hawser.service' → '/usr/lib/systemd/system/hawser.service'.
```

Verify config was created:
```
root@debiantest2:/mnt/debian-temp# cat /etc/hawser/config 
# Hawser Configuration
# See https://github.com/Finsys/hawser for documentation

DOCKER_SOCKET=/run/docker.sock
BIND_ADDRESS=10.123.1.70
PORT=2376
TOKEN=helloworldtest
```

Verify service starts successfully:
```
root@debiantest2:/mnt/debian-temp# service hawser status
● hawser.service - Hawser - Remote Docker Agent for Dockhand
     Loaded: loaded (/usr/lib/systemd/system/hawser.service; enabled; preset: enabled)
    Drop-In: /run/systemd/system/service.d
             └─zzz-lxc-service.conf
     Active: active (running) since Mon 2026-08-10 04:29:51 UTC; 1min 13s ago
 Invocation: c2b137dd0f424b67a2736d2fdbb13a70
       Docs: https://github.com/Finsys/hawser
   Main PID: 4074 (hawser)
      Tasks: 8 (limit: 154019)
     Memory: 5.3M (peak: 6.8M)
        CPU: 12ms
     CGroup: /system.slice/hawser.service
             └─4074 /usr/bin/hawser

Aug 10 04:29:51 debiantest2 hawser[4074]: │           Dockhand                  │
Aug 10 04:29:51 debiantest2 hawser[4074]: ╰─────────────────────────────────────╯
Aug 10 04:29:51 debiantest2 hawser[4074]: Version: 0.0.0-SNAPSHOT-9967fa8 (9967fa8)
Aug 10 04:29:51 debiantest2 hawser[4074]: Agent ID: 7a502229-d2d1-4a78-841f-e355150270a2
Aug 10 04:29:51 debiantest2 hawser[4074]: Agent Name: debiantest2
Aug 10 04:29:51 debiantest2 hawser[4074]: Docker Socket: /run/docker.sock
Aug 10 04:29:51 debiantest2 hawser[4074]: Log Level: INFO
Aug 10 04:29:51 debiantest2 hawser[4074]: 2026/08/10 04:29:51 [INFO] Starting in Standard mode on port 2376
Aug 10 04:29:51 debiantest2 hawser[4074]: 2026/08/10 04:29:51 [INFO] Connected to Docker 29.7.2 (API 1.55)
Aug 10 04:29:51 debiantest2 hawser[4074]: 2026/08/10 04:29:51 [INFO] Starting HTTP server on 10.123.1.70:2376

```
