### PR TITLE
feat(server): expose host disk usage in /_hawser/info (Standard mode)

### DIFF
--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Finsys/hawser/internal/docker"
+	"github.com/Finsys/hawser/internal/log"
 	"github.com/Finsys/hawser/internal/protocol"
 )
 
@@ -62,12 +63,18 @@ func (c *Collector) Collect() (*protocol.HostMetrics, error) {
 	// Skip if SKIP_DF_COLLECTION is set (useful for NAS devices with many mounted volumes
 	// where statfs calls can be slow and cause performance issues)
 	if os.Getenv("SKIP_DF_COLLECTION") == "" {
-		diskTotal, diskUsed, diskFree, err := c.collectDisk()
-		if err == nil {
-			metrics.DiskTotal = diskTotal
-			metrics.DiskUsed = diskUsed
-			metrics.DiskFree = diskFree
+		dataRoot, rootErr := c.dockerClient.GetDataRoot(context.Background())
+		if rootErr != nil {
+			dataRoot = "/var/lib/docker"
 		}
+
+		diskTotal, diskUsed, diskFree, err := DiskUsage(dataRoot)
+		if err != nil {
+			// Leave Disk* nil so the field is omitted from the outgoing JSON
+			// instead of reporting a misleading 0 (see HostMetrics doc comment).
+			log.Warnf("Disk metrics unavailable for %s: %v", dataRoot, err)
+		}
+		applyDiskMetrics(metrics, diskTotal, diskUsed, diskFree, err)
 	}
 
 	// Collect network stats
@@ -214,16 +221,16 @@ func (c *Collector) collectMemorySyscall() (total, used, free uint64, err error)
 	return 0, 0, 0, nil
 }
 
-// collectDisk reads disk usage for Docker data root
-func (c *Collector) collectDisk() (total, used, free uint64, err error) {
-	// Get Docker data root
-	dataRoot, err := c.dockerClient.GetDataRoot(context.Background())
-	if err != nil {
-		dataRoot = "/var/lib/docker"
-	}
-
+// DiskUsage reads disk usage for the given path (typically the Docker data
+// root). It is exported and package-level -- rather than a Collector method
+// -- so it can be tested directly against a real or a deliberately missing
+// path without a live Docker client, and so it can be reused by callers
+// that do not run the periodic Edge-mode Collector at all, such as the
+// Standard-mode HTTP server's /_hawser/info handler
+// (internal/server.addDiskInfo).
+func DiskUsage(path string) (total, used, free uint64, err error) {
 	var stat syscall.Statfs_t
-	if err := syscall.Statfs(dataRoot, &stat); err != nil {
+	if err := syscall.Statfs(path, &stat); err != nil {
 		return 0, 0, 0, err
 	}
 
@@ -232,6 +239,20 @@ func (c *Collector) collectDisk() (total, used, free uint64, err error) {
 	used = total - free
 
 	return total, used, free, nil
+}
+
+// applyDiskMetrics writes the collectDisk() result onto m. On success it
+// stores pointers to the values so a legitimate 0 (e.g. an empty data root)
+// still marshals as "0" on the wire. On failure it leaves the fields nil so
+// they are omitted from the outgoing JSON instead of silently reporting a
+// misleading 0 for "no data available".
+func applyDiskMetrics(m *protocol.HostMetrics, total, used, free uint64, err error) {
+	if err != nil {
+		return
+	}
+	m.DiskTotal = &total
+	m.DiskUsed = &used
+	m.DiskFree = &free
 }
 
 // collectNetwork reads network interface statistics

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Finsys/hawser/internal/protocol"
+)
+
+// TestDiskUsage_Success verifies that a valid, statable path returns
+// non-error disk figures with total == used + free.
+func TestDiskUsage_Success(t *testing.T) {
+	total, used, free, err := DiskUsage(t.TempDir())
+	if err != nil {
+		t.Fatalf("DiskUsage() unexpected error: %v", err)
+	}
+	if total == 0 {
+		t.Fatalf("DiskUsage() total = 0, want > 0 for a real filesystem")
+	}
+	if used+free != total {
+		t.Fatalf("DiskUsage() used(%d) + free(%d) != total(%d)", used, free, total)
+	}
+}
+
+// TestDiskUsage_Error verifies that a path invisible to statfs (e.g. not
+// mounted in the agent's mount namespace) returns an error rather than
+// silently reporting zeros. This is the failure path that HostMetrics'
+// pointer fields exist to distinguish from a legitimate 0.
+func TestDiskUsage_Error(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "nested", "path")
+
+	total, used, free, err := DiskUsage(missing)
+	if err == nil {
+		t.Fatalf("DiskUsage(%q) expected error, got nil (total=%d used=%d free=%d)", missing, total, used, free)
+	}
+	if total != 0 || used != 0 || free != 0 {
+		t.Fatalf("DiskUsage() on error = (%d, %d, %d), want all zero", total, used, free)
+	}
+}
+
+// TestApplyDiskMetrics_Error verifies that applyDiskMetrics -- the function
+// Collect() uses to write the DiskUsage() result onto HostMetrics -- keeps
+// the Disk* pointer fields nil on a collection error, so the field is
+// omitted from the outgoing JSON instead of reporting a misleading 0.
+func TestApplyDiskMetrics_Error(t *testing.T) {
+	m := &protocol.HostMetrics{}
+
+	applyDiskMetrics(m, 0, 0, 0, os.ErrNotExist)
+
+	if m.DiskTotal != nil || m.DiskUsed != nil || m.DiskFree != nil {
+		t.Fatalf("applyDiskMetrics() on error = (%v, %v, %v), want all nil",
+			m.DiskTotal, m.DiskUsed, m.DiskFree)
+	}
+}
+
+// TestApplyDiskMetrics_Success verifies that applyDiskMetrics stores the
+// values -- including a legitimate 0 -- as non-nil pointers on success, so
+// they marshal as a real number rather than being omitted.
+func TestApplyDiskMetrics_Success(t *testing.T) {
+	m := &protocol.HostMetrics{}
+
+	applyDiskMetrics(m, 1000, 400, 0, nil) // free == 0 is a legitimate value
+
+	if m.DiskTotal == nil || *m.DiskTotal != 1000 {
+		t.Fatalf("DiskTotal = %v, want pointer to 1000", m.DiskTotal)
+	}
+	if m.DiskUsed == nil || *m.DiskUsed != 400 {
+		t.Fatalf("DiskUsed = %v, want pointer to 400", m.DiskUsed)
+	}
+	if m.DiskFree == nil || *m.DiskFree != 0 {
+		t.Fatalf("DiskFree = %v, want non-nil pointer to 0 (legitimate zero, not omitted)", m.DiskFree)
+	}
+}
+
+// TestCollect_DiskCollectionFailurePropagates ties the pieces together at
+// the Collect() level for the failure path only: with SKIP_DF_COLLECTION
+// set, disk collection is skipped entirely, so Disk* must stay nil. This
+// does not require a Docker socket.
+func TestCollect_DiskCollectionSkipped(t *testing.T) {
+	t.Setenv("SKIP_DF_COLLECTION", "1")
+
+	c := NewCollector(nil)
+	metrics, err := c.Collect()
+	if err != nil {
+		t.Fatalf("Collect() unexpected error: %v", err)
+	}
+
+	if metrics.DiskTotal != nil || metrics.DiskUsed != nil || metrics.DiskFree != nil {
+		t.Fatalf("Collect() Disk* = (%v, %v, %v), want all nil when disk collection is skipped",
+			metrics.DiskTotal, metrics.DiskUsed, metrics.DiskFree)
+	}
+}

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -201,18 +201,26 @@ type MetricsMessage struct {
 }
 
 // HostMetrics contains CPU, memory, and disk statistics
+//
+// DiskTotal/DiskUsed/DiskFree are pointers so a failed disk stat (e.g. the
+// Docker data-root path is not visible in the agent's mount namespace) can be
+// represented as an absent field instead of a misleading 0. A plain uint64
+// zero value is indistinguishable from "0 bytes free", which previously made
+// "disk stat failed" look identical to "disk is full" on the receiving end.
+// A nil pointer marshals as an omitted field (via `omitempty`); a non-nil
+// pointer marshals as the real number, including a legitimate 0.
 type HostMetrics struct {
-	CPUUsage       float64 `json:"cpuUsage"`       // Percentage (0-100)
-	CPUCores       int     `json:"cpuCores"`       // Number of cores
-	MemoryTotal    uint64  `json:"memoryTotal"`    // Bytes
-	MemoryUsed     uint64  `json:"memoryUsed"`     // Bytes
-	MemoryFree     uint64  `json:"memoryFree"`     // Bytes
-	DiskTotal      uint64  `json:"diskTotal"`      // Bytes (Docker data-root)
-	DiskUsed       uint64  `json:"diskUsed"`       // Bytes
-	DiskFree       uint64  `json:"diskFree"`       // Bytes
-	NetworkRxBytes uint64  `json:"networkRxBytes"` // Total received bytes
-	NetworkTxBytes uint64  `json:"networkTxBytes"` // Total transmitted bytes
-	Uptime         uint64  `json:"uptime"`         // Host uptime in seconds
+	CPUUsage       float64 `json:"cpuUsage"`            // Percentage (0-100)
+	CPUCores       int     `json:"cpuCores"`            // Number of cores
+	MemoryTotal    uint64  `json:"memoryTotal"`         // Bytes
+	MemoryUsed     uint64  `json:"memoryUsed"`          // Bytes
+	MemoryFree     uint64  `json:"memoryFree"`          // Bytes
+	DiskTotal      *uint64 `json:"diskTotal,omitempty"` // Bytes (Docker data-root); nil when unavailable
+	DiskUsed       *uint64 `json:"diskUsed,omitempty"`  // Bytes; nil when unavailable
+	DiskFree       *uint64 `json:"diskFree,omitempty"`  // Bytes; nil when unavailable
+	NetworkRxBytes uint64  `json:"networkRxBytes"`      // Total received bytes
+	NetworkTxBytes uint64  `json:"networkTxBytes"`      // Total transmitted bytes
+	Uptime         uint64  `json:"uptime"`              // Host uptime in seconds
 }
 
 // NewMetricsMessage creates a new metrics message

--- a/internal/protocol/messages_test.go
+++ b/internal/protocol/messages_test.go
@@ -1,0 +1,117 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestHostMetrics_DiskFieldsOmittedWhenNil verifies that nil Disk* pointers
+// (set by the collector when a disk stat fails) are omitted from the JSON
+// wire format entirely, rather than serialized as 0. This is the fix for
+// the bug where a failed statfs was indistinguishable from a legitimately
+// empty disk on the Dockhand side.
+func TestHostMetrics_DiskFieldsOmittedWhenNil(t *testing.T) {
+	m := HostMetrics{
+		CPUCores:    4,
+		MemoryTotal: 1000,
+		// DiskTotal, DiskUsed, DiskFree intentionally left nil.
+		Uptime: 42,
+	}
+
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	for _, key := range []string{`"diskTotal"`, `"diskUsed"`, `"diskFree"`} {
+		if strings.Contains(string(out), key) {
+			t.Errorf("Marshal() output contains %s, want it omitted when nil: %s", key, out)
+		}
+	}
+
+	// Non-disk fields must still be present -- only the disk fields are
+	// pointer/omitempty.
+	for _, key := range []string{`"cpuCores"`, `"memoryTotal"`, `"uptime"`} {
+		if !strings.Contains(string(out), key) {
+			t.Errorf("Marshal() output missing %s: %s", key, out)
+		}
+	}
+
+	// Round-trip: unmarshaling must leave the pointers nil, not a pointer
+	// to zero.
+	var decoded HostMetrics
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	if decoded.DiskTotal != nil || decoded.DiskUsed != nil || decoded.DiskFree != nil {
+		t.Errorf("Unmarshal() Disk* = (%v, %v, %v), want all nil", decoded.DiskTotal, decoded.DiskUsed, decoded.DiskFree)
+	}
+}
+
+// TestHostMetrics_DiskFieldsPresentWhenSet verifies that a legitimate zero
+// value (e.g. DiskFree == 0 on a full disk) is still sent on the wire as an
+// actual "0", not omitted -- distinguishing it from "no data available".
+func TestHostMetrics_DiskFieldsPresentWhenSet(t *testing.T) {
+	total := uint64(1000)
+	used := uint64(1000)
+	free := uint64(0) // legitimate zero: disk is full
+
+	m := HostMetrics{
+		DiskTotal: &total,
+		DiskUsed:  &used,
+		DiskFree:  &free,
+	}
+
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	if !strings.Contains(string(out), `"diskFree":0`) {
+		t.Errorf("Marshal() output = %s, want \"diskFree\":0 present (legitimate zero, not omitted)", out)
+	}
+
+	var decoded HostMetrics
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+	if decoded.DiskTotal == nil || *decoded.DiskTotal != total {
+		t.Errorf("DiskTotal = %v, want pointer to %d", decoded.DiskTotal, total)
+	}
+	if decoded.DiskFree == nil || *decoded.DiskFree != 0 {
+		t.Errorf("DiskFree = %v, want non-nil pointer to 0", decoded.DiskFree)
+	}
+}
+
+// TestHostMetrics_LegacyConsumerCompat verifies that a consumer decoding
+// into the pre-fix, plain-uint64 shape (no pointers) still succeeds and
+// gets 0 for an omitted disk field -- i.e. the wire change is additive and
+// does not break a reader that has not been updated yet.
+func TestHostMetrics_LegacyConsumerCompat(t *testing.T) {
+	type legacyHostMetrics struct {
+		CPUCores  int    `json:"cpuCores"`
+		DiskTotal uint64 `json:"diskTotal"`
+		DiskUsed  uint64 `json:"diskUsed"`
+		DiskFree  uint64 `json:"diskFree"`
+	}
+
+	m := HostMetrics{CPUCores: 2} // Disk* nil -> omitted
+
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+
+	var legacy legacyHostMetrics
+	if err := json.Unmarshal(out, &legacy); err != nil {
+		t.Fatalf("legacy Unmarshal() error: %v", err)
+	}
+	if legacy.CPUCores != 2 {
+		t.Errorf("legacy.CPUCores = %d, want 2", legacy.CPUCores)
+	}
+	if legacy.DiskTotal != 0 || legacy.DiskUsed != 0 || legacy.DiskFree != 0 {
+		t.Errorf("legacy Disk* = (%d, %d, %d), want all 0 (Go zero value for an absent field)",
+			legacy.DiskTotal, legacy.DiskUsed, legacy.DiskFree)
+	}
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Finsys/hawser/internal/config"
 	"github.com/Finsys/hawser/internal/docker"
 	"github.com/Finsys/hawser/internal/log"
+	"github.com/Finsys/hawser/internal/metrics"
 	"github.com/Finsys/hawser/internal/pool"
 )
 
@@ -506,8 +507,7 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 	// Get host uptime
 	uptime := getHostUptime()
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	info := map[string]interface{}{
 		"agentId":       s.cfg.AgentID,
 		"agentName":     s.cfg.AgentName,
 		"dockerVersion": dockerVersion,
@@ -515,7 +515,42 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 		"mode":          "standard",
 		"uptime":        uptime,
 		"capabilities":  []string{"exec", "metrics", "events", "compose", "git-sync-delete"},
-	})
+	}
+
+	// Disk usage for the Docker data root, mirroring the field names Edge
+	// mode sends via the periodic metrics channel (protocol.HostMetrics).
+	// Standard mode has no running metrics.Collector, so this is a one-shot
+	// stat rather than a subscription to Collector's periodic push -- see
+	// addDiskInfo. Respects SKIP_DF_COLLECTION for the same reason Edge mode
+	// does: on hosts with many mounted volumes, statfs can be slow.
+	if os.Getenv("SKIP_DF_COLLECTION") == "" {
+		dataRoot, err := s.dockerClient.GetDataRoot(r.Context())
+		if err != nil {
+			dataRoot = "/var/lib/docker"
+		}
+		addDiskInfo(info, dataRoot)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(info)
+}
+
+// addDiskInfo augments info with diskTotal/diskUsed/diskFree (bytes) for the
+// given path, typically the Docker data root. It is split out from
+// handleInfo so it can be unit-tested directly against a real or a
+// deliberately missing path, without a live Docker client or an HTTP round
+// trip. On a stat failure it leaves info unchanged instead of writing a
+// misleading 0 -- the same "absent means unavailable" convention
+// internal/metrics.HostMetrics uses on the Edge-mode wire format.
+func addDiskInfo(info map[string]interface{}, dataRoot string) {
+	total, used, free, err := metrics.DiskUsage(dataRoot)
+	if err != nil {
+		log.Debugf("Disk info unavailable for %s: %v", dataRoot, err)
+		return
+	}
+	info["diskTotal"] = total
+	info["diskUsed"] = used
+	info["diskFree"] = free
 }
 
 // handleCompose handles Docker Compose operations

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestAddDiskInfo_Success verifies that a valid, statable path adds
+// diskTotal/diskUsed/diskFree to the info map with the same values
+// DiskUsage() reports, so /_hawser/info exposes real numbers on success.
+func TestAddDiskInfo_Success(t *testing.T) {
+	info := map[string]interface{}{"mode": "standard"}
+
+	addDiskInfo(info, t.TempDir())
+
+	total, ok := info["diskTotal"].(uint64)
+	if !ok || total == 0 {
+		t.Fatalf("info[diskTotal] = %v (ok=%v), want a non-zero uint64", info["diskTotal"], ok)
+	}
+	used, ok := info["diskUsed"].(uint64)
+	if !ok {
+		t.Fatalf("info[diskUsed] = %v (ok=%v), want a uint64", info["diskUsed"], ok)
+	}
+	free, ok := info["diskFree"].(uint64)
+	if !ok {
+		t.Fatalf("info[diskFree] = %v (ok=%v), want a uint64", info["diskFree"], ok)
+	}
+	if used+free != total {
+		t.Fatalf("used(%d) + free(%d) != total(%d)", used, free, total)
+	}
+
+	// Unrelated keys must survive untouched.
+	if info["mode"] != "standard" {
+		t.Fatalf("info[mode] = %v, want unchanged \"standard\"", info["mode"])
+	}
+}
+
+// TestAddDiskInfo_Error verifies that a path invisible to statfs leaves the
+// info map without disk keys, instead of writing a misleading 0 -- mirroring
+// the nil-pointer convention protocol.HostMetrics uses on the Edge-mode
+// wire format (see collector_test.go in internal/metrics).
+func TestAddDiskInfo_Error(t *testing.T) {
+	info := map[string]interface{}{"mode": "standard"}
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "nested", "path")
+
+	addDiskInfo(info, missing)
+
+	for _, key := range []string{"diskTotal", "diskUsed", "diskFree"} {
+		if _, present := info[key]; present {
+			t.Errorf("info[%s] = %v, want key absent after a stat failure", key, info[key])
+		}
+	}
+	if info["mode"] != "standard" {
+		t.Fatalf("info[mode] = %v, want unchanged \"standard\"", info["mode"])
+	}
+}


### PR DESCRIPTION
> **Stacked on #91** — this branch builds on `fix/disk-metrics-omitempty` (it reuses the
> `metrics.DiskUsage()` export introduced there). Please merge / rebase after #91; until then the
> diff here includes #91's commit.

## Problem

Standard mode's `/_hawser/info` only ever reported `uptime` -- no CPU, memory, or disk -- because
`metrics.Collector` (the thing that gathers all of that for Edge mode's periodic metrics push) is
never instantiated in the Standard-mode server. Disk space running out unnoticed is a real,
distinct problem for single-node Standard deployments, independent of the Edge-mode metrics
channel (see Finsys/dockhand#976, Finsys/dockhand#1397).

## Change

Add a one-shot `diskTotal`/`diskUsed`/`diskFree` (bytes) to the `/_hawser/info` response, using
the same field names Edge mode sends on the metrics wire. Reuses `metrics.DiskUsage(path)`
(exported in #91) rather than duplicating the `statfs` logic or instantiating a full `Collector`
-- Standard mode already holds a `*docker.Client` (`s.dockerClient`), so resolving the data root
and statting it is a cheap, stateless per-request call.

On a stat failure the three keys are simply left out of the response, matching the
"absent means unavailable" convention from #91 -- not a misleading `0`. Respects
`SKIP_DF_COLLECTION` for the same reason Edge mode does (hosts with many mounted volumes can
make `statfs` slow).

## Out of scope (deliberately)

CPU and memory are **not** added here. Doing so would mean either duplicating `Collector`'s
CPU-delta/mutex state per HTTP request, or instantiating a long-lived `Collector` inside the
Standard-mode server -- both larger design decisions (does Standard mode get a periodic metrics
loop of its own? does `/_hawser/info` become a snapshot of that, or stay request-driven?) that
are better made as their own change/issue rather than folded into a disk-only fix. Disk is
uniquely simple here because a single `statfs` call is stateless; CPU usage needs two samples
over time.

## Tests

New `internal/server/http_test.go` (package had no tests before):

- `addDiskInfo()` success path: real temp dir, `used + free == total`, unrelated map keys
  untouched
- `addDiskInfo()` error path: missing path → all three `disk*` keys absent, not `0`

`go build ./...`, `go vet ./...`, `go test ./... -race` all pass.
