### PR TITLE
build: align docker-compose pin with dockhand (5.1.4-r5 -> 5.5.0-r0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - ca-certificates" \
     "    - busybox" \
     "    - docker-cli" \
-    "    - docker-compose=5.1.4-r5" \
+    "    - docker-compose=5.5.0-r0" \
     "    - docker-cli-buildx" \
     "    - wget" \
     "entrypoint:" \


### PR DESCRIPTION
### What

Bumps the pinned `docker-compose` package in `Dockerfile` (line 45) from `5.1.4-r5` to
`5.5.0-r0`, matching the pin already used in `Finsys/dockhand`.

### Why

The pin is exact (`=5.1.4-r5`), so this image cannot pick up Wolfi security rebuilds of
`docker-compose` — unlike `docker-cli` and `docker-cli-buildx` on the neighbouring lines,
which are unpinned. The pin last moved on 2026-06-14; Wolfi has published several
security rebuilds since.

Dockhand appears to handle this already. Its `Dockerfile` carries the same apko package
list and has been kept current:

| | hawser | dockhand |
|---|---|---|
| `docker-compose` pin | `5.1.4-r5` (2026-06-14) | `5.5.0-r0` (2026-08-19) |
| latest release | v0.2.46 (2026-06-28) | v1.0.43 (2026-08-20) |

This PR simply brings hawser's pin in line with the value dockhand already uses.

### Impact

Scanning `ghcr.io/finsys/hawser:latest` (v0.2.46) with Trivy reports 8 findings against
`docker-compose 5.1.4-r5`. All eight have fixes at or below `5.5.0-r0`:

| CVE | Severity | Fixed in | Component |
|---|---|---|---|
| CVE-2026-50195 | CRITICAL | 5.1.4-r6 | containerd (CRI checkpoint image) |
| CVE-2026-53492 | CRITICAL | 5.1.4-r6 | containerd (CDI security bypass) |
| CVE-2026-53488 | HIGH | 5.1.4-r6 | containerd (unvalidated image) |
| CVE-2026-41178 | HIGH | 5.2.0-r0 | opentelemetry-go baggage |
| CVE-2026-56852 | HIGH | 5.3.1-r3 | golang.org/x/text (DoS) |
| CVE-2026-47262 | MEDIUM | 5.1.4-r6 | containerd (DoS via crafted image) |
| CVE-2026-53489 | MEDIUM | 5.1.4-r6 | containerd (symlink host file read) |
| CVE-2026-42505 | MEDIUM | 5.3.1-r1 | crypto/tls (ECH info disclosure) |

Note that `CVE-2026-56852` is one of the issues dockhand's 2026-07-31 bump to `5.3.1-r3`
addressed, so the fix path is already established in the sibling repo.

About severity: I am **not** reporting an exploitable condition in
hawser. In my own deployment I assessed these as not applicable — the containerd findings
hang off vendored CRI code that is not reachable in this image, and CRI is not in use.
This PR is about the *supply* of fixes rather than current exposure: with an exact pin,
a future compose CVE that **is** reachable would be equally unreachable by an update.

### Alternative, if the 5.1.4 line was pinned deliberately

If staying on the 5.1.4 feature line is intentional, a prefix constraint keeps that
intent while still allowing security rebuilds:

    - docker-compose~5.1.4

apk's `~` operator matches any version with that prefix, so this accepts `5.1.4-r6` and
later revisions but never moves to `5.2.x`. Happy to change this PR to that form instead —
whichever you prefer.

### Notes

- Wolfi currently also has `5.5.0-r1` and `5.5.0-r2` available, if you would rather take a newer revision.
- `Dockerfile.armv7` does not install docker-compose; `Dockerfile.dev` already installs it
  unpinned. This PR touches only the production `Dockerfile`.
- Line 84 already notes "newer docker-compose packages already ship this symlink", and the
  `ln -sf` there handles the newer layout, so no other change appears to be needed.
