### PR TITLE
fix: give compose operations their own timeout instead of RequestTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ DOCKER_SOCKET=/var/run/docker.sock
 
 # Connection settings (optional)
 # HEARTBEAT_INTERVAL=30
+# REQUEST_TIMEOUT=30
+# COMPOSE_TIMEOUT=900
 # RECONNECT_DELAY=1
 # MAX_RECONNECT_DELAY=60
 # WELCOME_TIMEOUT=30
@@ -474,6 +476,7 @@ Hawser is configured via environment variables:
 | `AGENT_NAME` | Human-readable agent name | Hostname |
 | `HEARTBEAT_INTERVAL` | Heartbeat interval in seconds | `30` |
 | `REQUEST_TIMEOUT` | Request timeout in seconds | `30` |
+| `COMPOSE_TIMEOUT` | Compose operation timeout in seconds (up/down/pull can run far longer than a normal request) | `900` |
 | `RECONNECT_DELAY` | Initial reconnect delay (Edge mode) | `1` |
 | `MAX_RECONNECT_DELAY` | Maximum reconnect delay | `60` |
 | `WELCOME_TIMEOUT` | Timeout in seconds waiting for welcome after hello (Edge mode) | `30` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	// Timeouts and intervals (seconds)
 	HeartbeatInterval int // Default: 30
 	RequestTimeout    int // Default: 30
+	ComposeTimeout    int // Default: 900 (compose operations can run far longer than a normal request)
 	ReconnectDelay    int // Initial reconnect delay, default: 1
 	MaxReconnectDelay int // Max reconnect delay, default: 60
 	WelcomeTimeout    int // Timeout waiting for welcome message after hello, default: 30
@@ -78,6 +79,7 @@ func Load() (*Config, error) {
 		// Timeouts
 		HeartbeatInterval: getEnvInt("HEARTBEAT_INTERVAL", 30),
 		RequestTimeout:    getEnvInt("REQUEST_TIMEOUT", 30),
+		ComposeTimeout:    getEnvInt("COMPOSE_TIMEOUT", 900),
 		ReconnectDelay:    getEnvInt("RECONNECT_DELAY", 1),
 		MaxReconnectDelay: getEnvInt("MAX_RECONNECT_DELAY", 60),
 		WelcomeTimeout:    getEnvInt("WELCOME_TIMEOUT", 30),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,3 +70,33 @@ func TestValidate_EdgeMode_Unaffected(t *testing.T) {
 		t.Fatalf("edge-mode validate() unexpected error: %v", err)
 	}
 }
+
+// TestLoad_ComposeTimeout verifies ComposeTimeout defaults to 900s and can be
+// overridden via COMPOSE_TIMEOUT, mirroring how RequestTimeout already
+// behaves. DOCKER_HOST is set so Load() skips the local docker-socket
+// existence check, isolating the timeout-parsing behavior under test.
+func TestLoad_ComposeTimeout(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://localhost:2375")
+	t.Setenv("TOKEN", "test-token")
+
+	t.Run("defaults to 900 when unset", func(t *testing.T) {
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.ComposeTimeout != 900 {
+			t.Errorf("ComposeTimeout = %d, want 900", cfg.ComposeTimeout)
+		}
+	})
+
+	t.Run("overridden via COMPOSE_TIMEOUT", func(t *testing.T) {
+		t.Setenv("COMPOSE_TIMEOUT", "120")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.ComposeTimeout != 120 {
+			t.Errorf("ComposeTimeout = %d, want 120", cfg.ComposeTimeout)
+		}
+	})
+}

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -436,6 +436,19 @@ func (c *Client) handleMessage(data []byte) {
 	}
 }
 
+// requestTimeout returns the context timeout to use for a non-streaming
+// request. Compose operations (up/down/pull) can legitimately run far longer
+// than a normal Docker API call — pulling images, recreating containers and
+// waiting on depends_on health checks routinely take minutes — so they get
+// their own timeout (ComposeTimeout, default 900s) instead of inheriting the
+// short RequestTimeout (default 30s) meant for ordinary Docker API calls.
+func (c *Client) requestTimeout(path string) time.Duration {
+	if path == "/_hawser/compose" {
+		return time.Duration(c.cfg.ComposeTimeout) * time.Second
+	}
+	return time.Duration(c.cfg.RequestTimeout) * time.Second
+}
+
 // handleRequest processes Docker API requests
 func (c *Client) handleRequest(req *protocol.RequestMessage) {
 	log.Infof("Docker API request: %s %s (streaming=%v)", req.Method, req.Path, req.Streaming)
@@ -452,8 +465,11 @@ func (c *Client) handleRequest(req *protocol.RequestMessage) {
 		return
 	}
 
-	// Non-streaming requests use a timeout context
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.cfg.RequestTimeout)*time.Second)
+	// Non-streaming requests use a timeout context. Compose operations get
+	// their own, separately configurable timeout (see requestTimeout) since
+	// image pulls, container recreation and depends_on health-check waits can
+	// legitimately run far longer than a normal Docker API call.
+	ctx, cancel := context.WithTimeout(context.Background(), c.requestTimeout(req.Path))
 	defer cancel()
 
 	// Check if this is a compose operation

--- a/internal/edge/client_test.go
+++ b/internal/edge/client_test.go
@@ -1,0 +1,53 @@
+package edge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Finsys/hawser/internal/config"
+)
+
+// TestRequestTimeout_ComposeGetsOwnBudget verifies that compose requests use
+// ComposeTimeout, and every other path (including a path that merely
+// contains "compose" as a substring) falls back to RequestTimeout. Before
+// this fix, /_hawser/compose inherited RequestTimeout, so a long-running
+// deploy (image pull + container recreation + depends_on health-check wait)
+// was aborted at 30s even though it was still making progress.
+func TestRequestTimeout_ComposeGetsOwnBudget(t *testing.T) {
+	cfg := &config.Config{RequestTimeout: 30, ComposeTimeout: 900}
+	c := &Client{cfg: cfg}
+
+	tests := []struct {
+		name string
+		path string
+		want time.Duration
+	}{
+		{"compose path gets ComposeTimeout", "/_hawser/compose", 900 * time.Second},
+		{"regular docker path gets RequestTimeout", "/containers/json", 30 * time.Second},
+		{"path containing compose as substring is not special-cased", "/_hawser/compose/logs", 30 * time.Second},
+		{"root path gets RequestTimeout", "/", 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.requestTimeout(tt.path); got != tt.want {
+				t.Errorf("requestTimeout(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRequestTimeout_ComposeLongerThanRequest is the regression guard: it
+// fails if ComposeTimeout is ever wired back to RequestTimeout (the original
+// bug), regardless of what default values either field happens to have.
+func TestRequestTimeout_ComposeLongerThanRequest(t *testing.T) {
+	cfg := &config.Config{RequestTimeout: 30, ComposeTimeout: 900}
+	c := &Client{cfg: cfg}
+
+	composeBudget := c.requestTimeout("/_hawser/compose")
+	requestBudget := c.requestTimeout("/containers/json")
+
+	if composeBudget <= requestBudget {
+		t.Fatalf("compose timeout (%v) must be greater than the plain request timeout (%v)", composeBudget, requestBudget)
+	}
+}


### PR DESCRIPTION
Fixes #95.

### Problem

`handleRequest` in `internal/edge/client.go` creates a single
`RequestTimeout`-bound context (default 30s) for all non-streaming requests,
and compose operations (`/_hawser/compose`) go through that same branch.
Streaming is already exempted a few lines above for the same reason ("can
run indefinitely") — compose wasn't, even though pulling images, recreating
containers, and waiting on `depends_on` health checks routinely takes longer
than 30s. When it does, the subprocess is killed, `ComposeResult.Success`
comes back `false`, and Dockhand shows a failed deploy for a compose run
that was very plausibly about to succeed.

Dockhand already treats compose as needing more time on its side —
`src/lib/server/docker.ts` uses a 300s edge-connection timeout and a
separate `COMPOSE_TIMEOUT` (default 900s) for compose specifically — so this
also fixes an asymmetry between the two ends of the same request.

### Fix

- Added `ComposeTimeout` to `internal/config` (env var `COMPOSE_TIMEOUT`,
  default `900`, matching Dockhand's own default so the two sides agree).
- Extracted the context-timeout selection in `handleRequest` into a small
  `requestTimeout(path string) time.Duration` method: returns
  `ComposeTimeout` for `/_hawser/compose`, `RequestTimeout` otherwise. This
  keeps `handleRequest` itself unchanged in structure (still one
  `context.WithTimeout` call, same compose check placement) while making the
  timeout choice unit-testable without a live Docker socket or WebSocket
  connection.
- Documented `COMPOSE_TIMEOUT` in the README (env var table + example env
  file).

### Design choice I'd like your take on

I gave compose its own bounded timeout (`COMPOSE_TIMEOUT`, default 900s)
rather than no timeout at all (the way streaming is handled). Reasoning: a
compose invocation is a bounded subprocess call, not an open-ended stream —
if it truly never returns (hung daemon, stuck health check with no
`start_period`/retry limit, etc.) it should still eventually be torn down
rather than leaking forever. Happy to switch to "no timeout, mirror
streaming" if you'd rather match that pattern instead.

### Tests

- `internal/edge/client_test.go` (new): table test on `requestTimeout()`
  covering the compose path, a plain Docker API path, a path that merely
  *contains* `compose` as a substring (to make sure the check stays an exact
  match), and an explicit "compose budget > request budget" regression
  guard.
- `internal/config/config_test.go`: `COMPOSE_TIMEOUT` defaults to 900 and is
  overridable, mirroring the existing pattern used for the other timeout
  env vars.
- Counter-tested locally: reverting `requestTimeout()` to always return
  `RequestTimeout` (the original bug) turns both new `internal/edge` tests
  red with a clear diagnostic (`want 15m0s`, `got 30s`); reverting the
  `COMPOSE_TIMEOUT` default to something other than 900 turns the config
  test red the same way. Restored before pushing.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

No behavior changes for streaming or ordinary (non-compose) requests.
