### PR TITLE
fix: explain compose failures caused by our own timeout, not the compose run itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ DOCKER_SOCKET=/var/run/docker.sock
 
 # Connection settings (optional)
 # HEARTBEAT_INTERVAL=30
+# REQUEST_TIMEOUT=30
+# COMPOSE_TIMEOUT=900
 # RECONNECT_DELAY=1
 # MAX_RECONNECT_DELAY=60
 # WELCOME_TIMEOUT=30
@@ -474,6 +476,7 @@ Hawser is configured via environment variables:
 | `AGENT_NAME` | Human-readable agent name | Hostname |
 | `HEARTBEAT_INTERVAL` | Heartbeat interval in seconds | `30` |
 | `REQUEST_TIMEOUT` | Request timeout in seconds | `30` |
+| `COMPOSE_TIMEOUT` | Compose operation timeout in seconds (up/down/pull can run far longer than a normal request) | `900` |
 | `RECONNECT_DELAY` | Initial reconnect delay (Edge mode) | `1` |
 | `MAX_RECONNECT_DELAY` | Maximum reconnect delay | `60` |
 | `WELCOME_TIMEOUT` | Timeout in seconds waiting for welcome after hello (Edge mode) | `30` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	// Timeouts and intervals (seconds)
 	HeartbeatInterval int // Default: 30
 	RequestTimeout    int // Default: 30
+	ComposeTimeout    int // Default: 900 (compose operations can run far longer than a normal request)
 	ReconnectDelay    int // Initial reconnect delay, default: 1
 	MaxReconnectDelay int // Max reconnect delay, default: 60
 	WelcomeTimeout    int // Timeout waiting for welcome message after hello, default: 30
@@ -78,6 +79,7 @@ func Load() (*Config, error) {
 		// Timeouts
 		HeartbeatInterval: getEnvInt("HEARTBEAT_INTERVAL", 30),
 		RequestTimeout:    getEnvInt("REQUEST_TIMEOUT", 30),
+		ComposeTimeout:    getEnvInt("COMPOSE_TIMEOUT", 900),
 		ReconnectDelay:    getEnvInt("RECONNECT_DELAY", 1),
 		MaxReconnectDelay: getEnvInt("MAX_RECONNECT_DELAY", 60),
 		WelcomeTimeout:    getEnvInt("WELCOME_TIMEOUT", 30),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,3 +70,33 @@ func TestValidate_EdgeMode_Unaffected(t *testing.T) {
 		t.Fatalf("edge-mode validate() unexpected error: %v", err)
 	}
 }
+
+// TestLoad_ComposeTimeout verifies ComposeTimeout defaults to 900s and can be
+// overridden via COMPOSE_TIMEOUT, mirroring how RequestTimeout already
+// behaves. DOCKER_HOST is set so Load() skips the local docker-socket
+// existence check, isolating the timeout-parsing behavior under test.
+func TestLoad_ComposeTimeout(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://localhost:2375")
+	t.Setenv("TOKEN", "test-token")
+
+	t.Run("defaults to 900 when unset", func(t *testing.T) {
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.ComposeTimeout != 900 {
+			t.Errorf("ComposeTimeout = %d, want 900", cfg.ComposeTimeout)
+		}
+	})
+
+	t.Run("overridden via COMPOSE_TIMEOUT", func(t *testing.T) {
+		t.Setenv("COMPOSE_TIMEOUT", "120")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.ComposeTimeout != 120 {
+			t.Errorf("ComposeTimeout = %d, want 120", cfg.ComposeTimeout)
+		}
+	})
+}

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -591,6 +591,26 @@ func (c *Client) handleStreamingRequest(req *protocol.RequestMessage, headers ma
 	}
 }
 
+// annotateComposeTimeout rewrites result.Error to explicitly call out that
+// the compose operation was aborted because our own context timeout expired
+// — as opposed to a genuine compose failure (missing image, invalid compose
+// file, ...). When the context expires, exec.CommandContext kills the
+// docker-compose subprocess and cmd.Run() returns a generic error such as
+// "signal: killed"; Go's exec package never surfaces "context deadline
+// exceeded" through that error, so on its own it looks exactly like an
+// ordinary compose failure. ctx.Err() is the only reliable way to tell the
+// two apart. The original error/progress output is preserved, just no
+// longer left to stand alone as the (misleading) cause.
+func (c *Client) annotateComposeTimeout(ctx context.Context, result *docker.ComposeResult) {
+	if result.Success || !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return
+	}
+	result.Error = fmt.Sprintf(
+		"compose operation aborted: exceeded the %ds COMPOSE_TIMEOUT (raise COMPOSE_TIMEOUT if this operation legitimately needs more time); underlying error: %s",
+		c.cfg.ComposeTimeout, result.Error,
+	)
+}
+
 // handleComposeRequest handles Docker Compose operations
 func (c *Client) handleComposeRequest(ctx context.Context, req *protocol.RequestMessage) {
 	var op docker.ComposeOperation
@@ -606,6 +626,8 @@ func (c *Client) handleComposeRequest(ctx context.Context, req *protocol.Request
 		c.sendJSON(protocol.NewErrorMessage(req.RequestID, err.Error(), "COMPOSE_ERROR"))
 		return
 	}
+
+	c.annotateComposeTimeout(ctx, result)
 
 	respBody, _ := json.Marshal(result)
 	statusCode := http.StatusOK

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -436,6 +436,19 @@ func (c *Client) handleMessage(data []byte) {
 	}
 }
 
+// requestTimeout returns the context timeout to use for a non-streaming
+// request. Compose operations (up/down/pull) can legitimately run far longer
+// than a normal Docker API call — pulling images, recreating containers and
+// waiting on depends_on health checks routinely take minutes — so they get
+// their own timeout (ComposeTimeout, default 900s) instead of inheriting the
+// short RequestTimeout (default 30s) meant for ordinary Docker API calls.
+func (c *Client) requestTimeout(path string) time.Duration {
+	if path == "/_hawser/compose" {
+		return time.Duration(c.cfg.ComposeTimeout) * time.Second
+	}
+	return time.Duration(c.cfg.RequestTimeout) * time.Second
+}
+
 // handleRequest processes Docker API requests
 func (c *Client) handleRequest(req *protocol.RequestMessage) {
 	log.Infof("Docker API request: %s %s (streaming=%v)", req.Method, req.Path, req.Streaming)
@@ -452,8 +465,11 @@ func (c *Client) handleRequest(req *protocol.RequestMessage) {
 		return
 	}
 
-	// Non-streaming requests use a timeout context
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.cfg.RequestTimeout)*time.Second)
+	// Non-streaming requests use a timeout context. Compose operations get
+	// their own, separately configurable timeout (see requestTimeout) since
+	// image pulls, container recreation and depends_on health-check waits can
+	// legitimately run far longer than a normal Docker API call.
+	ctx, cancel := context.WithTimeout(context.Background(), c.requestTimeout(req.Path))
 	defer cancel()
 
 	// Check if this is a compose operation

--- a/internal/edge/client_test.go
+++ b/internal/edge/client_test.go
@@ -1,10 +1,13 @@
 package edge
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Finsys/hawser/internal/config"
+	"github.com/Finsys/hawser/internal/docker"
 )
 
 // TestRequestTimeout_ComposeGetsOwnBudget verifies that compose requests use
@@ -49,5 +52,94 @@ func TestRequestTimeout_ComposeLongerThanRequest(t *testing.T) {
 
 	if composeBudget <= requestBudget {
 		t.Fatalf("compose timeout (%v) must be greater than the plain request timeout (%v)", composeBudget, requestBudget)
+	}
+}
+
+// pastDeadlineContext returns a context whose deadline is already behind us,
+// so ctx.Err() is context.DeadlineExceeded immediately — no need to sleep out
+// a real timeout to exercise the "context already expired" branch.
+func pastDeadlineContext() context.Context {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	cancel() // avoid a leak lint warning; the deadline already fired synchronously
+	return ctx
+}
+
+// TestAnnotateComposeTimeout_ExpiredContextOnFailure is the case this fix
+// exists for: the docker-compose subprocess got killed because our own
+// context timeout expired, and cmd.Run() surfaces that as a generic error
+// (e.g. "signal: killed") indistinguishable from a real compose failure. The
+// annotation must name the setting (COMPOSE_TIMEOUT), state the configured
+// duration, and keep the original error text rather than discard it.
+func TestAnnotateComposeTimeout_ExpiredContextOnFailure(t *testing.T) {
+	c := &Client{cfg: &config.Config{ComposeTimeout: 900}}
+	result := &docker.ComposeResult{
+		Success: false,
+		Output:  "Pulling web ... \nCreating app_web_1 ... \n",
+		Error:   "signal: killed",
+	}
+
+	c.annotateComposeTimeout(pastDeadlineContext(), result)
+
+	if !strings.Contains(result.Error, "COMPOSE_TIMEOUT") {
+		t.Errorf("annotated error = %q, want it to name COMPOSE_TIMEOUT", result.Error)
+	}
+	if !strings.Contains(result.Error, "900") {
+		t.Errorf("annotated error = %q, want it to state the configured duration (900)", result.Error)
+	}
+	if !strings.Contains(result.Error, "signal: killed") {
+		t.Errorf("annotated error = %q, want the original error preserved, not discarded", result.Error)
+	}
+	if !strings.Contains(result.Output, "Creating app_web_1") {
+		t.Errorf("Output = %q, must not be touched by the annotation", result.Output)
+	}
+}
+
+// TestAnnotateComposeTimeout_LeavesGenuineFailureAlone verifies a real
+// compose failure (context still live, e.g. a missing image) is untouched —
+// only a context-timeout-caused failure gets the extra explanation.
+func TestAnnotateComposeTimeout_LeavesGenuineFailureAlone(t *testing.T) {
+	c := &Client{cfg: &config.Config{ComposeTimeout: 900}}
+	result := &docker.ComposeResult{
+		Success: false,
+		Error:   "pull access denied for ghcr.io/example/missing, repository does not exist",
+	}
+	want := result.Error
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour) // nowhere near expiring
+	defer cancel()
+	c.annotateComposeTimeout(ctx, result)
+
+	if result.Error != want {
+		t.Errorf("annotateComposeTimeout changed a genuine failure's error: got %q, want unchanged %q", result.Error, want)
+	}
+}
+
+// TestAnnotateComposeTimeout_LeavesSuccessAlone: an expired context racing
+// against a subprocess that happened to finish successfully must not have
+// its (empty) error field rewritten into a spurious timeout notice.
+func TestAnnotateComposeTimeout_LeavesSuccessAlone(t *testing.T) {
+	c := &Client{cfg: &config.Config{ComposeTimeout: 900}}
+	result := &docker.ComposeResult{Success: true, Output: "done"}
+
+	c.annotateComposeTimeout(pastDeadlineContext(), result)
+
+	if result.Error != "" {
+		t.Errorf("annotateComposeTimeout touched a successful result: Error = %q, want empty", result.Error)
+	}
+}
+
+// TestAnnotateComposeTimeout_PlainCancelIsNotDeadlineExceeded: an explicitly
+// canceled context (context.Canceled) is a different signal than a timeout
+// (context.DeadlineExceeded) and must not trigger the timeout annotation.
+func TestAnnotateComposeTimeout_PlainCancelIsNotDeadlineExceeded(t *testing.T) {
+	c := &Client{cfg: &config.Config{ComposeTimeout: 900}}
+	result := &docker.ComposeResult{Success: false, Error: "signal: killed"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.annotateComposeTimeout(ctx, result)
+
+	if result.Error != "signal: killed" {
+		t.Errorf("annotateComposeTimeout fired on plain cancellation: Error = %q, want unchanged", result.Error)
 	}
 }

--- a/internal/edge/client_test.go
+++ b/internal/edge/client_test.go
@@ -1,0 +1,53 @@
+package edge
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Finsys/hawser/internal/config"
+)
+
+// TestRequestTimeout_ComposeGetsOwnBudget verifies that compose requests use
+// ComposeTimeout, and every other path (including a path that merely
+// contains "compose" as a substring) falls back to RequestTimeout. Before
+// this fix, /_hawser/compose inherited RequestTimeout, so a long-running
+// deploy (image pull + container recreation + depends_on health-check wait)
+// was aborted at 30s even though it was still making progress.
+func TestRequestTimeout_ComposeGetsOwnBudget(t *testing.T) {
+	cfg := &config.Config{RequestTimeout: 30, ComposeTimeout: 900}
+	c := &Client{cfg: cfg}
+
+	tests := []struct {
+		name string
+		path string
+		want time.Duration
+	}{
+		{"compose path gets ComposeTimeout", "/_hawser/compose", 900 * time.Second},
+		{"regular docker path gets RequestTimeout", "/containers/json", 30 * time.Second},
+		{"path containing compose as substring is not special-cased", "/_hawser/compose/logs", 30 * time.Second},
+		{"root path gets RequestTimeout", "/", 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.requestTimeout(tt.path); got != tt.want {
+				t.Errorf("requestTimeout(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRequestTimeout_ComposeLongerThanRequest is the regression guard: it
+// fails if ComposeTimeout is ever wired back to RequestTimeout (the original
+// bug), regardless of what default values either field happens to have.
+func TestRequestTimeout_ComposeLongerThanRequest(t *testing.T) {
+	cfg := &config.Config{RequestTimeout: 30, ComposeTimeout: 900}
+	c := &Client{cfg: cfg}
+
+	composeBudget := c.requestTimeout("/_hawser/compose")
+	requestBudget := c.requestTimeout("/containers/json")
+
+	if composeBudget <= requestBudget {
+		t.Fatalf("compose timeout (%v) must be greater than the plain request timeout (%v)", composeBudget, requestBudget)
+	}
+}


### PR DESCRIPTION
Fixes #97. Builds on #96 (adds `ComposeTimeout`, which this PR's message
refers to by name) — **this branch is stacked on `fix/compose-request-timeout`
and its diff/commit list includes that PR's single commit as well as this
PR's own commit.** If you'd rather review the two independently, please say
so — I can rework this one to name `REQUEST_TIMEOUT` generically instead and
drop the dependency, at the cost of the message becoming wrong again as soon
as #96 (or something like it) lands. Went with the dependent version since
both fixes touch the same failure mode and I'd assume you'd want to review
them together, but happy to split differently.

### Problem

When the context governing `/_hawser/compose` expires, `exec.CommandContext`
kills the `docker-compose` subprocess, and `cmd.Run()` returns a generic
error (`signal: killed`) that carries no indication a timeout happened —
Go's `exec` package doesn't surface `context.DeadlineExceeded` through that
error. `Execute` (`internal/docker/compose.go`) folds this straight into
`ComposeResult.Error`, so a killed-by-timeout run and a genuinely failed one
(bad image, invalid compose file, ...) are indistinguishable to whoever is
looking at the result.

### Fix

`handleComposeRequest` now calls a small `annotateComposeTimeout(ctx,
result)` after `Execute` returns. It only acts when `result.Success` is
`false` **and** `errors.Is(ctx.Err(), context.DeadlineExceeded)` — i.e.
exactly the case where our own context is why the subprocess died, not a
genuine compose failure and not some other kind of cancellation. When it
fires, it prepends an explanation naming `COMPOSE_TIMEOUT` and its
configured value to `result.Error`, keeping the original error/output
intact rather than replacing them.

### Tests

`internal/edge/client_test.go`, four cases on the extracted
`annotateComposeTimeout`:
- Expired context + failed result → message names `COMPOSE_TIMEOUT`, states
  the configured duration, and keeps the original error text; `Output` is
  untouched.
- Failed result with a context nowhere near expiring (genuine failure) →
  `Error` unchanged.
- Expired context but `Success: true` (the subprocess finished right as the
  deadline passed) → `Error` unchanged, no spurious annotation on a success.
- Explicitly canceled context (`context.Canceled`, not a timeout) → `Error`
  unchanged — only `DeadlineExceeded` triggers this.

Counter-tested: reverted `annotateComposeTimeout` to a no-op locally, which
turned the first test red with a clear diagnostic (`want it to name
COMPOSE_TIMEOUT`, `want it to state the configured duration`) while the other
three (which assert "unchanged") stayed green, as expected for a no-op.
Restored the fix afterward; `go build ./...`, `go vet ./...`, `go test ./...`
all pass.

No changes to the actual compose invocation or timeout behavior — this is
purely about what the error message says when a timeout is the cause.
