### PR TITLE
feat(compose): stream output lines and fall back to stderr

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1,11 +1,13 @@
 package docker
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -178,8 +180,40 @@ func (c *ComposeClient) loginToRegistries(ctx context.Context, registries []Regi
 	}
 }
 
-// Execute runs a Docker Compose operation
-func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*ComposeResult, error) {
+// teeLines wires dst (the buffer Execute already accumulates for the final
+// result) to also emit complete lines to onLine as they arrive. If onLine is
+// nil, it returns dst unchanged and a no-op closer -- today's behavior.
+//
+// The caller MUST call the returned close() after cmd.Run() returns: io.Pipe
+// is synchronous, the scanner only flushes its final unterminated line on
+// EOF, and without the close the scanner goroutine blocks forever -- a leak
+// on every call.
+func teeLines(dst *bytes.Buffer, onLine func(string)) (io.Writer, func()) {
+	if onLine == nil {
+		return dst, func() {}
+	}
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(pr)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // compose lines can be long
+		for sc.Scan() {
+			onLine(sc.Text())
+		}
+	}()
+	return io.MultiWriter(dst, pw), func() {
+		pw.Close() // flushes the scanner's final line
+		<-done     // no line may arrive after Execute returned
+	}
+}
+
+// Execute runs a Docker Compose operation. onLine, if non-nil, is invoked
+// with each complete line of stdout/stderr as the compose command produces
+// it (interleaved across both streams, same as a terminal would show them).
+// Pass nil for today's behavior: buffered output only, returned in the
+// result once the command has finished.
+func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation, onLine func(string)) (*ComposeResult, error) {
 	// Detect compose command on first use
 	if err := c.detectComposeCommand(); err != nil {
 		return &ComposeResult{
@@ -483,10 +517,15 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 	// Log the command being executed
 	log.Debugf("Compose: %s %s (project=%s)", c.composeCmd, strings.Join(fullArgs, " "), op.ProjectName)
 
-	// Capture output
+	// Capture output. Compose writes progress to stderr, not stdout in most
+	// cases -- but WITH a build the bulk of the output lands on stdout
+	// (measured in task 0), so both streams are wired to onLine, not stderr
+	// alone.
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdoutWriter, closeStdout := teeLines(&stdout, onLine)
+	stderrWriter, closeStderr := teeLines(&stderr, onLine)
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 
 	// Pipe compose content via stdin if provided
 	if stdinContent != "" {
@@ -494,6 +533,8 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 	}
 
 	err := cmd.Run()
+	closeStdout() // after Run(), before the streamed buffers are read below
+	closeStderr()
 
 	result := &ComposeResult{
 		Success:      err == nil,
@@ -546,6 +587,13 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation) (*Com
 		if strings.HasPrefix(strings.TrimSpace(stderr.String()), "[") {
 			result.Output = stderr.String()
 		}
+	}
+
+	// Fall back to stderr: compose writes its progress there, so stdout is
+	// usually empty. This runs after the ps/JSON special case above so it
+	// only kicks in when neither of them already produced an output.
+	if strings.TrimSpace(result.Output) == "" {
+		result.Output = stderr.String()
 	}
 
 	return result, nil

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -121,6 +121,12 @@ type ComposeOperation struct {
 	PullPolicy      string                `json:"pullPolicy,omitempty"`      // Pull policy: 'always' | 'missing' | 'never'
 	FilesToDelete   []FileToDelete        `json:"filesToDelete,omitempty"`   // Git deletion sync (#966): hash-verified file removals
 	RemoveFiles     bool                  `json:"removeFiles,omitempty"`     // On down: remove the stack directory entirely (#1162, stack deletion only)
+	// StreamOutput requests that Execute's onLine callback be wired up, so the
+	// caller receives one message per output line as the compose command runs
+	// instead of only the buffered result at the end. Defaults to false: a
+	// caller that doesn't know this field (an older Dockhand) gets exactly the
+	// old behavior, never unsolicited per-line messages.
+	StreamOutput bool `json:"streamOutput,omitempty"`
 }
 
 // ComposeResult is the result of a compose operation
@@ -213,6 +219,13 @@ func teeLines(dst *bytes.Buffer, onLine func(string)) (io.Writer, func()) {
 // it (interleaved across both streams, same as a terminal would show them).
 // Pass nil for today's behavior: buffered output only, returned in the
 // result once the command has finished.
+//
+// onLine is called from two separate goroutines -- one teeLines scanner for
+// stdout, one for stderr, running concurrently for the lifetime of the
+// command -- so it MUST be safe to call from multiple goroutines at once.
+// A callback that only forwards to something already safe for concurrent
+// use (e.g. Client.sendJSON, which takes its own lock) needs no extra
+// synchronization; a callback with its own mutable state does.
 func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation, onLine func(string)) (*ComposeResult, error) {
 	// Detect compose command on first use
 	if err := c.detectComposeCommand(); err != nil {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Finsys/hawser/internal/log"
 )
@@ -202,14 +203,30 @@ func teeLines(dst *bytes.Buffer, onLine func(string)) (io.Writer, func()) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		sc := bufio.NewScanner(pr)
-		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // compose lines can be long
-		for sc.Scan() {
-			onLine(sc.Text())
+		// Close the read end on the way out no matter how we exit. ReadString
+		// removes the one known early-return (Scanner's ErrTooLong on a >1MB
+		// line), but a future one -- e.g. a panic in onLine -- would again
+		// leave the writer with no reader and block it forever. Closing pr
+		// hands any further write ErrClosedPipe instead of a permanent block.
+		defer pr.Close()
+		// bufio.Reader, not bufio.Scanner: Scanner caps a line at its buffer
+		// size and, once a line exceeds it, stops reading -- which leaves the
+		// pipe with no reader and blocks the compose subprocess's writes
+		// forever (cmd.Run never returns). ReadString has no such cap and
+		// returns the trailing partial line on EOF.
+		br := bufio.NewReader(pr)
+		for {
+			line, err := br.ReadString('\n')
+			if len(line) > 0 {
+				onLine(strings.TrimRight(line, "\n"))
+			}
+			if err != nil {
+				return // io.EOF on pw.Close(), or a pipe error
+			}
 		}
 	}()
 	return io.MultiWriter(dst, pw), func() {
-		pw.Close() // flushes the scanner's final line
+		pw.Close() // EOF to the reader: flushes any final unterminated line
 		<-done     // no line may arrive after Execute returned
 	}
 }
@@ -484,6 +501,13 @@ func (c *ComposeClient) Execute(ctx context.Context, op *ComposeOperation, onLin
 
 	// Execute compose command
 	cmd := exec.CommandContext(ctx, c.composeCmd, fullArgs...)
+
+	// Structural guard for the whole "Wait() hangs on an output-copy goroutine"
+	// class: when the context fires, exec kills the process but Wait() still
+	// blocks on the stdout/stderr copier. WaitDelay caps that wait -- after the
+	// process is gone, Wait() returns within WaitDelay even if a copier is
+	// wedged, so a timeout always bites regardless of which writer stalls.
+	cmd.WaitDelay = 10 * time.Second
 
 	// Set working directory (use stackDir if files were written, otherwise use WorkDir)
 	if stackDir != "" {

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -61,10 +62,19 @@ func TestOutputFallsBackToStderr(t *testing.T) {
 // forgets to wire cmd.Stdout -- this test builds a trivial one-line image and
 // checks that a marker written by the build reaches onLine.
 //
-// Skips if Docker is unavailable or unreachable, since this is the one test
-// in this package that needs a real daemon rather than just the compose CLI
-// failing fast on its own.
+// Gated behind HAWSER_TEST_DOCKER: this is the only test in the repo that
+// needs Docker to actually build an image rather than just fail fast on its
+// own, and this package's other tests intentionally have no external
+// dependency. Running it unconditionally would make it the first test in an
+// external contributor's CI run to spin up a real image build -- a fair
+// objection from a maintainer who wasn't expecting that. Set
+// HAWSER_TEST_DOCKER=1 to run it locally; it also skips (rather than fails)
+// if Docker turns out to be unavailable or unreachable even with the switch
+// set.
 func TestExecuteEmitsBuildOutputFromStdout(t *testing.T) {
+	if os.Getenv("HAWSER_TEST_DOCKER") == "" {
+		t.Skip("set HAWSER_TEST_DOCKER=1 to run tests that build images with docker compose")
+	}
 	if _, err := exec.LookPath("docker"); err != nil {
 		t.Skip("docker not on PATH")
 	}

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -1,0 +1,47 @@
+package docker
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestExecuteEmitsLines verifies that Execute reports complete lines through
+// the onLine callback as they arrive. "ps" with no compose file present is a
+// harmless, deterministic operation: it never touches Docker state and always
+// fails fast with "no configuration file provided: not found" on stderr.
+func TestExecuteEmitsLines(t *testing.T) {
+	var lines []string
+	c := NewComposeClient("", t.TempDir())
+	op := &ComposeOperation{Operation: "ps"}
+	_, err := c.Execute(context.Background(), op, func(l string) { lines = append(lines, l) })
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(lines) == 0 {
+		t.Fatal("no lines emitted")
+	}
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		return // at least one non-empty line -- that is the assertion
+	}
+	t.Fatal("only empty lines emitted")
+}
+
+// TestOutputFallsBackToStderr verifies that Execute falls back to stderr for
+// result.Output when stdout is empty. "ps" without a compose file writes
+// exclusively to stderr (verified manually: stdout is empty, stderr carries
+// "no configuration file provided: not found"), so this is a real run that
+// exercises the fallback without needing an invented test helper.
+func TestOutputFallsBackToStderr(t *testing.T) {
+	c := NewComposeClient("", t.TempDir())
+	res, err := c.Execute(context.Background(), &ComposeOperation{Operation: "ps"}, nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Output, "no configuration file provided") {
+		t.Fatalf("Output = %q, want it to contain the stderr message (fallback did not apply)", res.Output)
+	}
+}

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -1,9 +1,11 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -114,4 +116,37 @@ func TestExecuteEmitsBuildOutputFromStdout(t *testing.T) {
 		}
 	}
 	t.Fatalf("build marker %q not seen in %d emitted lines -- stdout not wired to onLine?", marker, len(lines))
+}
+
+// TestTeeLinesFlushesFinalLineWithoutNewline verifies teeLines' closer
+// contract directly: the scanner only flushes an unterminated final line on
+// EOF, so the returned close() must trigger that EOF (by closing the pipe's
+// write end) before Execute reads the result. Without it, the last line of
+// output -- often the most important one, e.g. a build's final status line
+// -- would never reach onLine.
+func TestTeeLinesFlushesFinalLineWithoutNewline(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	var lines []string
+
+	w, closeFn := teeLines(&buf, func(l string) {
+		mu.Lock()
+		lines = append(lines, l)
+		mu.Unlock()
+	})
+
+	if _, err := w.Write([]byte("first line\nlast line without newline")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	closeFn()
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"first line", "last line without newline"}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("lines = %v, want %v", lines, want)
+	}
+	if buf.String() != "first line\nlast line without newline" {
+		t.Fatalf("buf = %q, teeLines must still write dst (Execute's result buffer)", buf.String())
+	}
 }

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -2,8 +2,12 @@ package docker
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // TestExecuteEmitsLines verifies that Execute reports complete lines through
@@ -44,4 +48,70 @@ func TestOutputFallsBackToStderr(t *testing.T) {
 	if !strings.Contains(res.Output, "no configuration file provided") {
 		t.Fatalf("Output = %q, want it to contain the stderr message (fallback did not apply)", res.Output)
 	}
+}
+
+// TestExecuteEmitsBuildOutputFromStdout verifies that Execute captures build
+// output specifically, because that is the one case where hooking stderr
+// alone (the naive reading of "compose writes progress to stderr") silently
+// drops the bulk of the output: a prior measurement found that WITHOUT a
+// build compose writes to stderr only, but WITH a build the build log lands
+// on stdout. TestExecuteEmitsLines alone cannot catch a regression that
+// forgets to wire cmd.Stdout -- this test builds a trivial one-line image and
+// checks that a marker written by the build reaches onLine.
+//
+// Skips if Docker is unavailable or unreachable, since this is the one test
+// in this package that needs a real daemon rather than just the compose CLI
+// failing fast on its own.
+func TestExecuteEmitsBuildOutputFromStdout(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not on PATH")
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skip("docker daemon not reachable")
+	}
+
+	const marker = "HAWSER_BUILD_OUTPUT_MARKER"
+	project := fmt.Sprintf("hawsertest%d", time.Now().UnixNano())
+
+	c := NewComposeClient("/var/run/docker.sock", t.TempDir())
+	op := &ComposeOperation{
+		Operation:   "up",
+		ProjectName: project,
+		Build:       true,
+		Files: map[string]string{
+			"docker-compose.yml": "services:\n  app:\n    build: .\n    command: [\"true\"]\n",
+			"Dockerfile":         "FROM alpine:3.20\nRUN echo " + marker + "\n",
+		},
+	}
+
+	t.Cleanup(func() {
+		_, _ = c.Execute(context.Background(), &ComposeOperation{
+			Operation:   "down",
+			ProjectName: project,
+		}, nil)
+		_ = exec.Command("docker", "rmi", project+"-app:latest").Run()
+	})
+
+	var mu sync.Mutex
+	var lines []string
+	res, err := c.Execute(context.Background(), op, func(l string) {
+		mu.Lock()
+		lines = append(lines, l)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("compose up --build failed: %s", res.Error)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, l := range lines {
+		if strings.Contains(l, marker) {
+			return // found on some line -- the assertion
+		}
+	}
+	t.Fatalf("build marker %q not seen in %d emitted lines -- stdout not wired to onLine?", marker, len(lines))
 }

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"reflect"
@@ -158,5 +159,66 @@ func TestTeeLinesFlushesFinalLineWithoutNewline(t *testing.T) {
 	}
 	if buf.String() != "first line\nlast line without newline" {
 		t.Fatalf("buf = %q, teeLines must still write dst (Execute's result buffer)", buf.String())
+	}
+}
+
+// TestTeeLinesHandlesHugeLineWithoutDeadlock guards the fix for the >1MB
+// unterminated-line deadlock: a bufio.Scanner capped at 1MB stops reading such
+// a line, leaving the pipe unread and blocking every further write to it. With
+// bufio.Reader the whole line is delivered and close() returns promptly.
+func TestTeeLinesHandlesHugeLineWithoutDeadlock(t *testing.T) {
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	var got []string
+	w, closeFn := teeLines(&buf, func(l string) {
+		mu.Lock()
+		got = append(got, l)
+		mu.Unlock()
+	})
+
+	huge := strings.Repeat("x", 2*1024*1024) // 2MB, no newline
+	payload := huge + "\nEND\n"
+
+	// The write itself blocks against the unfixed teeLines (the reader goroutine
+	// exits on ErrTooLong, so the pipe has no reader), so it MUST run off the
+	// test goroutine -- otherwise a broken teeLines hangs here until the whole
+	// package's test timeout rather than failing this test cleanly. Both the
+	// write and the close have to complete within the deadline.
+	writeDone := make(chan error, 1)
+	go func() {
+		if _, err := io.WriteString(w, payload); err != nil {
+			writeDone <- err
+			return
+		}
+		closeFn() // flushes the trailing "END" and joins the reader goroutine
+		writeDone <- nil
+	}()
+
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("write/close on a >1MB line did not complete in 5s -- teeLines deadlocked (scanner-cap regression)")
+	}
+
+	// Assert on the delivered content, not merely on "no deadlock": a >1MB line
+	// must reach onLine WHOLE, the trailing short line must follow, and dst (the
+	// buffer Execute returns as result.Output) must hold the raw bytes. The
+	// unfixed teeLines cannot satisfy these even if a harness happened to drain
+	// the pipe -- the huge line never reaches the capped scanner.
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{huge, "END"}
+	if !reflect.DeepEqual(got, want) {
+		desc := make([]string, len(got))
+		for i, l := range got {
+			desc[i] = fmt.Sprintf("%d bytes", len(l))
+		}
+		t.Fatalf("lines = %v, want [2MB line, \"END\"]", desc)
+	}
+	if buf.String() != payload {
+		t.Fatalf("dst buffer = %d bytes, want the full %d bytes written", buf.Len(), len(payload))
 	}
 }

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -621,7 +621,7 @@ func (c *Client) handleComposeRequest(ctx context.Context, req *protocol.Request
 
 	log.Infof("Compose operation: %s on %s", op.Operation, op.ProjectName)
 
-	result, err := c.compose.Execute(ctx, &op)
+	result, err := c.compose.Execute(ctx, &op, nil) // nil for now; task 7 wires a streaming callback here
 	if err != nil {
 		c.sendJSON(protocol.NewErrorMessage(req.RequestID, err.Error(), "COMPOSE_ERROR"))
 		return

--- a/internal/edge/client.go
+++ b/internal/edge/client.go
@@ -30,11 +30,22 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// composeExecutor is the subset of *docker.ComposeClient that Client needs.
+// Declared here (not as the concrete type) so tests can substitute a fake
+// that never shells out to a real docker/docker-compose binary -- Execute
+// would otherwise depend on Docker being installed, which this package's
+// tests are meant to avoid (see docker.ComposeClient.Execute, and the one
+// intentionally-gated Docker-dependent test in internal/docker).
+type composeExecutor interface {
+	Execute(ctx context.Context, op *docker.ComposeOperation, onLine func(string)) (*docker.ComposeResult, error)
+	IsAvailable() bool
+}
+
 // Client represents the Edge mode WebSocket client
 type Client struct {
 	cfg          *config.Config
 	dockerClient *docker.Client
-	compose      *docker.ComposeClient
+	compose      composeExecutor
 	metrics      *metrics.Collector
 	conn         *websocket.Conn
 	mu           sync.Mutex
@@ -621,7 +632,22 @@ func (c *Client) handleComposeRequest(ctx context.Context, req *protocol.Request
 
 	log.Infof("Compose operation: %s on %s", op.Operation, op.ProjectName)
 
-	result, err := c.compose.Execute(ctx, &op, nil) // nil for now; task 7 wires a streaming callback here
+	// Only send per-line stream messages when the caller asked for them
+	// (op.StreamOutput). An older Dockhand never sets this field, so it must
+	// never receive a "stream" message for a compose request -- it wouldn't
+	// know what to do with one. onLine is invoked from two goroutines
+	// concurrently (see docker.ComposeClient.Execute's doc comment); it needs
+	// no extra locking here because it only forwards to c.sendJSON, which
+	// already serializes writes to the connection under c.mu.
+	var onLine func(string)
+	if op.StreamOutput {
+		onLine = func(line string) {
+			// Same call shape as handleStreamingRequest (client.go:567).
+			c.sendJSON(protocol.NewStreamMessage(req.RequestID, []byte(line), ""))
+		}
+	}
+
+	result, err := c.compose.Execute(ctx, &op, onLine)
 	if err != nil {
 		c.sendJSON(protocol.NewErrorMessage(req.RequestID, err.Error(), "COMPOSE_ERROR"))
 		return

--- a/internal/edge/client_test.go
+++ b/internal/edge/client_test.go
@@ -2,13 +2,183 @@ package edge
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Finsys/hawser/internal/config"
 	"github.com/Finsys/hawser/internal/docker"
+	"github.com/Finsys/hawser/internal/protocol"
+	"github.com/gorilla/websocket"
 )
+
+// fakeComposeClient is a test double for composeExecutor. Execute never
+// shells out to a real docker/docker-compose binary -- it just calls onLine
+// with the canned lines and returns the canned result. That keeps these
+// tests independent of whether Docker is installed, unlike the one
+// Docker-dependent test in internal/docker (gated behind HAWSER_TEST_DOCKER).
+type fakeComposeClient struct {
+	lines  []string
+	result *docker.ComposeResult
+}
+
+func (f *fakeComposeClient) Execute(_ context.Context, _ *docker.ComposeOperation, onLine func(string)) (*docker.ComposeResult, error) {
+	if onLine != nil {
+		for _, l := range f.lines {
+			onLine(l)
+		}
+	}
+	if f.result != nil {
+		return f.result, nil
+	}
+	return &docker.ComposeResult{Success: true}, nil
+}
+
+func (f *fakeComposeClient) IsAvailable() bool { return true }
+
+// sentMessage is the minimal shape needed to classify a captured message by
+// its "type" field, without depending on every concrete protocol.*Message
+// type.
+type sentMessage struct {
+	Type      string `json:"type"`
+	RequestID string `json:"requestId"`
+}
+
+// captureSentMessages spins up a real (loopback) websocket server, connects
+// a *Client to it exactly like production code does, and returns that
+// client plus a drain function. sendJSON writes through a real
+// *websocket.Conn (gorilla, a concrete type -- there's no interface to fake
+// here without changing production code well beyond this task's scope), so
+// a real connection is the only way to observe what it sends.
+//
+// drain(wantType) blocks until a message of type wantType has been
+// received (handleComposeRequest always ends with exactly one "response" or
+// "error" message, so tests wait for that) or a timeout elapses, then
+// returns every message captured so far.
+func captureSentMessages(t *testing.T) (client *Client, drain func(wantType string) []sentMessage) {
+	t.Helper()
+
+	var (
+		mu  sync.Mutex
+		got []sentMessage
+	)
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var m sentMessage
+			if err := json.Unmarshal(data, &m); err != nil {
+				continue
+			}
+			mu.Lock()
+			got = append(got, m)
+			mu.Unlock()
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial test websocket server: %v", err)
+	}
+	t.Cleanup(func() { clientConn.Close() })
+
+	client = &Client{conn: clientConn}
+
+	drain = func(wantType string) []sentMessage {
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			mu.Lock()
+			for _, m := range got {
+				if m.Type == wantType {
+					out := make([]sentMessage, len(got))
+					copy(out, got)
+					mu.Unlock()
+					return out
+				}
+			}
+			mu.Unlock()
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for a %q message", wantType)
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	return client, drain
+}
+
+func countByType(msgs []sentMessage, typ string) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Type == typ {
+			n++
+		}
+	}
+	return n
+}
+
+func mustJSON(t *testing.T, v interface{}) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %#v: %v", v, err)
+	}
+	return data
+}
+
+func TestComposeRequestSendsLinesWhenAsked(t *testing.T) {
+	c, drain := captureSentMessages(t)
+	c.compose = &fakeComposeClient{lines: []string{"pulling image", "container started"}}
+
+	req := &protocol.RequestMessage{
+		RequestID: "req-1",
+		Path:      "/_hawser/compose",
+		Body:      mustJSON(t, docker.ComposeOperation{Operation: "up", StreamOutput: true}),
+	}
+	c.handleComposeRequest(context.Background(), req)
+
+	sent := drain("response")
+	if got := countByType(sent, "stream"); got == 0 {
+		t.Fatal("no line message sent, although StreamOutput was true")
+	}
+	if got := countByType(sent, "response"); got != 1 {
+		t.Fatalf("final response missing or sent more than once: got %d", got)
+	}
+}
+
+func TestComposeRequestStaysSilentByDefault(t *testing.T) {
+	c, drain := captureSentMessages(t)
+	c.compose = &fakeComposeClient{lines: []string{"pulling image", "container started"}}
+
+	req := &protocol.RequestMessage{
+		RequestID: "req-2",
+		Path:      "/_hawser/compose",
+		Body:      mustJSON(t, docker.ComposeOperation{Operation: "up"}), // no StreamOutput
+	}
+	c.handleComposeRequest(context.Background(), req)
+
+	sent := drain("response")
+	if got := countByType(sent, "stream"); got != 0 {
+		t.Fatalf("lines sent although not requested (got %d) -- breaks older Dockhand versions", got)
+	}
+	if got := countByType(sent, "response"); got != 1 {
+		t.Fatalf("final response missing or sent more than once: got %d", got)
+	}
+}
 
 // TestRequestTimeout_ComposeGetsOwnBudget verifies that compose requests use
 // ComposeTimeout, and every other path (including a path that merely

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -543,7 +543,7 @@ func (s *Server) handleCompose(w http.ResponseWriter, r *http.Request) {
 
 	log.Debugf("Compose operation: %s on %s", op.Operation, op.ProjectName)
 
-	result, err := s.compose.Execute(r.Context(), &op)
+	result, err := s.compose.Execute(r.Context(), &op, nil) // nil: REST has no channel for streamed lines
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(docker.ComposeResult{


### PR DESCRIPTION
## What this changes

Two things in the compose path, both needed before Dockhand can show a live console view for agent-managed environments (Finsys/dockhand#506, Finsys/dockhand#1499).

### 1. `Execute()` can report lines as they arrive

`internal/docker/compose.go` buffered stdout/stderr into `bytes.Buffer` and returned one block when the process exited. It now takes an optional line callback. **Without a callback the behaviour is unchanged** — same buffering, same return value.

`internal/edge/client.go`'s `handleComposeRequest` sets that callback when the caller asks for it (new `streamOutput` field in the payload) and sends one message per line, modelled on `handleStreamingRequest` in the same file.

### 2. `result.Output` falls back to stderr

`result.Output` was `stdout.String()` with no stderr fallback. Compose writes to **stderr**, so on the agent path a successful run returned an effectively empty output and Dockhand fell back to its placeholder text almost every time. The local path in Dockhand already does `stdout || stderr || placeholder`; this brings the agent path in line.

This is a small fix with a visible effect on its own — even without any Dockhand change, agent-side compose results stop coming back blank.

## Compatibility

`streamOutput` is a new optional payload field. Agents built before this change ignore it (`json.Unmarshal` without `DisallowUnknownFields`), and Dockhand reacts to whatever arrives — either line messages followed by the result, or just the result. No version negotiation.

Conversely, an agent with this change talking to a Dockhand without it simply never gets asked to stream.

## Related

- Finsys/dockhand#1499 — the Dockhand side. It stands alone without this PR (local environments stream immediately); this PR is what extends it to agent-managed environments.
- #96 and #98 — compose timeout. Without those, a long compose run is still killed by the generic `RequestTimeout` mid-stream, which with live output becomes very visible: you watch lines arrive and then it stops with no explanation. They are independent of this PR but land in the same area.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` all clean.

Added coverage for: `teeLines` flushing a final unterminated line on close, build output landing on stdout, and the stderr fallback. The docker-dependent build test is gated behind an env switch so it does not require a daemon in CI.
