### PR TITLE
build: bump docker-compose to 5.5.0-r2 and add git to the runtime images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,9 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - ca-certificates" \
     "    - busybox" \
     "    - docker-cli" \
-    "    - docker-compose=5.5.0-r0" \
+    "    - docker-compose=5.5.0-r2" \
     "    - docker-cli-buildx" \
+    "    - git" \
     "    - wget" \
     "entrypoint:" \
     "  command: /bin/sh -l" \

--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
     ca-certificates \
     docker-cli \
     docker-cli-compose \
+    git \
     wget \
     && mkdir -p /data/stacks
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -55,6 +55,7 @@ RUN APKO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") 
     "    - busybox" \
     "    - docker-cli" \
     "    - docker-compose" \
+    "    - git" \
     "    - wget" \
     "entrypoint:" \
     "  command: /bin/sh -l" \


### PR DESCRIPTION
## What

- Bump `docker-compose` to `5.5.0-r2` in the production image (was `5.5.0-r0`) so the agent matches the compose version dockhand ships.
- Add `git` to the runtime of all three images (Wolfi prod, Wolfi dev, Alpine armv7).

## Why

`git` was missing from the agent's runtime rootfs, so deploying a git-backed stack through a Hawser agent had no `git` binary available on the container. Adding it to each runtime image fixes that across all architectures. The dev and armv7 images keep their existing unpinned compose (they intentionally track the latest package); only the production image carries the exact pin, now aligned to dockhand's `5.5.0-r2`.

## Notes

- Both packages resolve in the current Wolfi index (`docker-compose 5.5.0-r2`, `git`), so the apko build resolves cleanly.
- No code changes; Dockerfile-only.
